### PR TITLE
Prevent silent email verification failure when Resend is not configured

### DIFF
--- a/joca-app/src/lib/auth.ts
+++ b/joca-app/src/lib/auth.ts
@@ -36,7 +36,7 @@ export const auth = betterAuth({
     },
     deleteUser: {
       enabled: true,
-      beforeDelete: async (user) => {
+      beforeDelete: async (user: { id: string; email: string }) => {
         // Cancel active Stripe subscription before deleting the user,
         // otherwise Stripe will continue billing the card indefinitely.
         const sub = await prisma.subscription.findUnique({
@@ -77,9 +77,20 @@ export const auth = betterAuth({
       process.env.NEXT_PUBLIC_SKIP_EMAIL_VERIFICATION !== "true",
   },
   emailVerification: {
-    sendVerificationEmail: async ({ user, url }) => {
+    sendVerificationEmail: async ({
+      user,
+      url,
+    }: {
+      user: { email: string; name: string };
+      url: string;
+    }) => {
+      if (!resend) {
+        throw new Error(
+          "Resend client not configured. Email verification is disabled."
+        );
+      }
       try {
-        await resend?.emails.send({
+        await resend.emails.send({
           from: "onboarding@resend.dev", //TODO: Change to JOCA email once prod domain is verified
           to: user.email,
           subject: "Verify your email",


### PR DESCRIPTION
Closes #125 

In sendVerificationEmail the optional chaining `resend?.emails.send(...)` returns `undefined` when `resend` is `null` (e.g., if `RESEND_API_KEY` is missing). This causes no error to be thrown, so Better Auth considers the email "sent" successfully even though no email was delivered.

In production, if `RESEND_API_KEY` is accidentally missing from deployment, users will never receive verification emails and will be permanently stuck unable to log in, with no server-side error logged.

## Changes

- Added explicit `if (!resend)` check in [sendVerificationEmail](cci:1://file:///Users/esosa/Documents/blueprint/JOCA/joca-app/src/lib/auth.ts:99:4-113:5) to throw a clear error when Resend client is not configured
- Removed optional chaining (`resend?.emails.send` → `resend.emails.send`) since we now guarantee `resend` is non-null
- Added type annotations to `user` and `url` parameters in sendVerificationEmail and beforeDelete hooks
