### PR TITLE
Prevent duplicate member creation and add phoneNumber validation

### DIFF
--- a/joca-app/src/app/payment/success/page.tsx
+++ b/joca-app/src/app/payment/success/page.tsx
@@ -14,36 +14,47 @@ import { NotLoggedIn } from "@/components/NotLoggedIn";
 import { createMember, getMemberByEmail } from "@/lib/actions";
 import { Member } from "@/lib/types";
 
+// Type extension for Better Auth session with additional fields
+type AuthUser = {
+  id: string;
+  email: string;
+  name: string;
+  phoneNumber?: string;
+};
+
 export default async function PaymentSuccessPage() {
   const authSession = await auth.api.getSession({ headers: await headers() });
   if (!authSession?.user) return <NotLoggedIn />;
 
+  const user = authSession.user as AuthUser;
+
   const activeSubscription = await prisma.subscription.findFirst({
-    where: { referenceId: authSession.user.id, status: "active" },
+    where: { referenceId: user.id, status: "active" },
   });
   const paymentVerified = activeSubscription ? true : false;
 
   //Console errors here can be found in Vercel logs
   if (paymentVerified) {
-    let existing: Member | null = null;
     try {
-      existing = await getMemberByEmail(authSession.user.email);
-    } catch (error) {
-      console.error(error);
-    }
-    try {
+      const existing = await getMemberByEmail(user.email);
       if (!existing) {
-        const [firstName, ...rest] = authSession.user.name.split(" ");
+        const [firstName, ...rest] = user.name.split(" ");
         const lastName = rest.join(" ");
+        
+        if (!user.phoneNumber) {
+          throw new Error("Phone number is required but not found in user session");
+        }
+        
         await createMember(
           firstName,
           lastName,
-          authSession.user.email,
-          authSession.user.phoneNumber,
+          user.email,
+          user.phoneNumber,
         );
       }
     } catch (error) {
-      console.error(error);
+      console.error("Failed to create member in Strapi:", error);
+      // Don't block the success page - member creation is not critical for payment confirmation
     }
   }
 

--- a/joca-app/src/app/payment/success/page.tsx
+++ b/joca-app/src/app/payment/success/page.tsx
@@ -12,21 +12,12 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { NotLoggedIn } from "@/components/NotLoggedIn";
 import { createMember, getMemberByEmail } from "@/lib/actions";
-import { Member } from "@/lib/types";
-
-// Type extension for Better Auth session with additional fields
-type AuthUser = {
-  id: string;
-  email: string;
-  name: string;
-  phoneNumber?: string;
-};
 
 export default async function PaymentSuccessPage() {
   const authSession = await auth.api.getSession({ headers: await headers() });
   if (!authSession?.user) return <NotLoggedIn />;
 
-  const user = authSession.user as AuthUser;
+  const { user } = authSession;
 
   const activeSubscription = await prisma.subscription.findFirst({
     where: { referenceId: user.id, status: "active" },
@@ -40,21 +31,19 @@ export default async function PaymentSuccessPage() {
       if (!existing) {
         const [firstName, ...rest] = user.name.split(" ");
         const lastName = rest.join(" ");
-        
+
         if (!user.phoneNumber) {
-          throw new Error("Phone number is required but not found in user session");
+          throw new Error(
+            "Phone number is required but not found in user session",
+          );
         }
-        
-        await createMember(
-          firstName,
-          lastName,
-          user.email,
-          user.phoneNumber,
-        );
+
+        await createMember(firstName, lastName, user.email, user.phoneNumber);
       }
     } catch (error) {
-      console.error("Failed to create member in Strapi:", error);
+      console.error("Failed to fetch/create member in Strapi:", error);
       // Don't block the success page - member creation is not critical for payment confirmation
+      //Page will still render. Will retry on next load
     }
   }
 

--- a/joca-app/src/lib/types.ts
+++ b/joca-app/src/lib/types.ts
@@ -1,8 +1,8 @@
 export type Candidate = {
   documentId: string;
-  member?: Member;
+  member: Member;
   voteCount: number;
-  election?: Election;
+  election: Election;
 };
 
 export type Event = {
@@ -23,7 +23,7 @@ export type Election = {
   category: "Executive" | "Committee" | "Referendum";
   votingDateStart: string; // ISO date (YYYY-MM-DD)
   votingDateEnd: string; // ISO date (YYYY-MM-DD)
-  candidates?: Candidate[];
+  candidates: Candidate[];
 };
 
 export type Member = {
@@ -31,7 +31,7 @@ export type Member = {
   firstName: string;
   lastName: string;
   email: string;
-  phoneNumber?: string;
+  phoneNumber: string;
   user?: User;
   candidate?: Candidate;
 };
@@ -39,13 +39,12 @@ export type Member = {
 export type User = {
   documentId: string;
   email: string;
-  phoneNumber?: string;
+  phoneNumber: string;
   provider?: string;
   password?: string;
   resetPasswordToken?: string;
   confirmationToken?: string;
   confirmed?: boolean;
   blocked?: boolean;
-  //   role: Role; // TODO: We don't have a content type for this yet but I'd guess "Authenticated" | "Public"?
   member?: Member;
 };


### PR DESCRIPTION
- Closes #117 & #118

### 1. Duplicate Member Creation on Strapi Errors 
**Problem:** Two separate try/catch blocks allowed execution to fall through. If getMemberByEmail threw an error (e.g., Strapi down), `existing` stayed `null` and code unconditionally called createMember, causing:
- Duplicate member creation attempts on every page reload
- Unique constraint violations (silently swallowed)
- Missing member records during partial outages

**Fix:** Merged into single try/catch block. If getMemberByEmail fails, entire block exits - no createMember call.

### 2. Missing phoneNumber Validation 
**Problem:** `authSession.user.phoneNumber` could be undefined but was passed directly to createMember, causing:
- Corrupt member records in Strapi (phoneNumber stored as null/undefined)
- Users unable to participate in elections
- Silent failures swallowed by try/catch

**Fix:** 
- Added proper AuthUser type definition
- Explicit validation: throws error if phoneNumber is missing
- Clear error messages for debugging
- Payment success page still renders (member creation is non-critical)

## Changes
- src/app/payment/success/page.tsx: Combined try/catch blocks, added phoneNumber validation, proper typing