### PR TITLE
Add email verification page with encoded name/email URI params

### DIFF
--- a/joca-app/src/app/elections/page.tsx
+++ b/joca-app/src/app/elections/page.tsx
@@ -20,7 +20,6 @@ export default async function ElectionsPage() {
     return <EmailNotVerified />;
 
   /*Use a direct prisma query to bypass the 60s cookie cache on session data*/
-  // "active" covers the grace period (Stripe keeps status active until periodEnd even after cancellation).
   // If trials are added in future, also include status: "trialing".
   const activeSubscription = await prisma.subscription.findFirst({
     where: { referenceId: session.user.id, status: "active" },

--- a/joca-app/src/app/email-verification/EmailVerificationPage.tsx
+++ b/joca-app/src/app/email-verification/EmailVerificationPage.tsx
@@ -20,7 +20,7 @@ const getSecondsRemaining = () => {
   );
 };
 
-export const EmailVerificationPage = ({
+export const EmailVerification = ({
   name,
   email,
 }: {
@@ -29,7 +29,10 @@ export const EmailVerificationPage = ({
 }) => {
   const [cooldown, setCooldown] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
   const { data: session } = useSession();
+
+  useEffect(() => setIsMounted(true), []);
 
   useEffect(() => {
     setCooldown(getSecondsRemaining());
@@ -64,7 +67,11 @@ export const EmailVerificationPage = ({
     }
   };
 
-  if (session?.user?.emailVerified && process.env.NEXT_PUBLIC_SKIP_EMAIL_VERIFICATION !== "true") {
+  if (
+    isMounted &&
+    session?.user?.emailVerified &&
+    process.env.NEXT_PUBLIC_SKIP_EMAIL_VERIFICATION !== "true"
+  ) {
     return (
       <div className="text-center text-muted-foreground flex flex-col items-center justify-center gap-4">
         Email verified already.

--- a/joca-app/src/app/email-verification/page.tsx
+++ b/joca-app/src/app/email-verification/page.tsx
@@ -1,0 +1,11 @@
+import { EmailVerification } from "./EmailVerificationPage";
+
+interface Props {
+  searchParams: Promise<{ name?: string; email?: string }>;
+}
+
+export default async function EmailVerificationPage({ searchParams }: Props) {
+  const { name, email } = await searchParams;
+
+  return <EmailVerification name={name ?? ""} email={email ?? ""} />;
+}

--- a/joca-app/src/app/signup/SignupForm.tsx
+++ b/joca-app/src/app/signup/SignupForm.tsx
@@ -12,7 +12,6 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
-import { EmailVerificationPage } from "./EmailVerificationPage";
 
 import {
   Form,
@@ -57,8 +56,6 @@ export const SignupForm = () => {
   const { data: session, isPending } = useSessionReady();
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [isEmailVerificationPageVisible, setIsEmailVerificationPageVisible] =
-    useState(false);
   const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => setIsMounted(true), []);
@@ -97,7 +94,7 @@ export const SignupForm = () => {
           if (process.env.NEXT_PUBLIC_SKIP_EMAIL_VERIFICATION === "true") {
             router.push("/payment");
           } else {
-            setIsEmailVerificationPageVisible(true);
+            router.push(`/email-verification?name=${encodeURIComponent(values.firstName)}&email=${encodeURIComponent(values.email)}`);
           }
         },
         onError: (ctx: any) => {
@@ -111,18 +108,6 @@ export const SignupForm = () => {
   if (!isMounted || isPending) return <Loading />;
 
   if (session?.user) return <AlreadyLoggedIn />;
-
-  if (
-    isEmailVerificationPageVisible &&
-    process.env.NEXT_PUBLIC_SKIP_EMAIL_VERIFICATION !== "true"
-  ) {
-    return (
-      <EmailVerificationPage
-        name={form.getValues("firstName")}
-        email={form.getValues("email")}
-      />
-    );
-  }
 
   return (
     <div className="font-sans my-12 flex flex-col items-center justify-items-center h-full gap-16">

--- a/joca-app/src/lib/auth.ts
+++ b/joca-app/src/lib/auth.ts
@@ -19,6 +19,7 @@ const resendApiKey = process.env.RESEND_API_KEY;
 if (!isDev && !resendApiKey) {
   throw new Error("RESEND_API_KEY environment variable is not set.");
 }
+
 const resend = isDev ? null : new Resend(resendApiKey!);
 
 export const auth = betterAuth({
@@ -86,7 +87,7 @@ export const auth = betterAuth({
     }) => {
       if (!resend) {
         throw new Error(
-          "Resend client not configured. Email verification is disabled."
+          "Resend client not configured. Email verification is disabled.",
         );
       }
       try {


### PR DESCRIPTION
Moved away from using state to trigger the email verification page (was not a reliable idea anyway as state can just reset after refresh) and inserted it into its own independent page route 

- Added isMounted state to prevent hydration errors when useSession is pending in client components (in this case the mismatch was between the server returning false for `session?.user?.emailVerified` and true when the client was hydrating)
- Because active sessions aren't created until emails are verified, we append the name/email through query params and fetch, pass those into `EmailVerificationPage`

Could consider cookies/localStorage instead of query params if there is a security/GDPR concern but they all have tradeoffs 