### PR TITLE
Removed DialogClose tags from submit and cancel button

### DIFF
--- a/joca-app/src/app/elections/ElectionCard.tsx
+++ b/joca-app/src/app/elections/ElectionCard.tsx
@@ -104,7 +104,6 @@ export const ElectionCard = ({ election }: { election: Election }) => {
               <MapPin className="opacity-70" />
               {election.location ?? "N/A"}
             </span>
-            <span>{userId ? "Logged in as " + userId : "Not logged in"}</span>
           </CardDescription>
         </CardHeader>
 
@@ -244,25 +243,21 @@ export const ElectionCard = ({ election }: { election: Election }) => {
                     cannot be undone.
                   </DialogDescription>
                   <DialogFooter>
-                    <DialogClose asChild>
-                      <Button
-                        className="cursor-pointer"
-                        variant="destructive"
-                        onClick={handleVote}
-                        disabled={voting || hasVoted}
-                      >
-                        Submit Vote
-                      </Button>
-                    </DialogClose>
-                    <DialogClose asChild>
-                      <Button
-                        onClick={() => setOpenVoteDialog(false)}
-                        className="cursor-pointer"
-                        variant="secondary"
-                      >
-                        Cancel
-                      </Button>
-                    </DialogClose>
+                    <Button
+                      className="cursor-pointer"
+                      variant="destructive"
+                      onClick={handleVote}
+                      disabled={voting || hasVoted}
+                    >
+                      Submit Vote
+                    </Button>
+                    <Button
+                      onClick={() => setOpenVoteDialog(false)}
+                      className="cursor-pointer"
+                      variant="secondary"
+                    >
+                      Cancel
+                    </Button>
                   </DialogFooter>
                 </DialogContent>
               </Dialog>


### PR DESCRIPTION
The outer dialog now gets controlled by state while the inner dialog is no longer controlled - using the `DialogClose` component was enough as there was no complex open/close requirements needed.

The outer dialog still needs state as we want it to open/close at specific times (e.g. close after an async operation such as submitting votes in Strapi). 