### PR TITLE
Reversed order of deletion - DB -> Stripe with console err requiring manual deletion if necessary

### DIFF
--- a/joca-app/src/lib/auth.ts
+++ b/joca-app/src/lib/auth.ts
@@ -38,22 +38,41 @@ export const auth = betterAuth({
     deleteUser: {
       enabled: true,
       beforeDelete: async (user: { id: string; email: string }) => {
-        // Cancel active Stripe subscription before deleting the user,
-        // otherwise Stripe will continue billing the card indefinitely.
+        // Find the subscription record
         const sub = await prisma.subscription.findUnique({
           where: { referenceId: user.id },
           select: { stripeSubscriptionId: true, status: true },
         });
-        if (sub?.status === "active" && sub?.stripeSubscriptionId) {
-          await stripeClient.subscriptions.cancel(sub.stripeSubscriptionId);
-        }
-        // Clean up subscription record - no FK cascade since referenceId
-        // has no @relation to User.
-        //Add check to prevent throwing error if it doesn't exist
         if (sub) {
-          await prisma.subscription.delete({
-            where: { referenceId: user.id },
-          });
+          // Delete the DB row first. If this throws, Stripe is untouched and
+          // both sides remain consistent - the error propagates and aborts deletion.
+          try {
+            await prisma.subscription.delete({
+              where: { referenceId: user.id },
+            });
+          } catch (error) {
+            console.error(
+              `Failed to delete subscription record for user ${user.id}:`,
+              error,
+            );
+            throw error;
+          }
+
+          // Cancel Stripe only after the DB row is gone. If Stripe fails here,
+          // the DB is already clean (no phantom active record), so log a billing
+          // alert for manual resolution but do not block account deletion.
+          // Can check the alert in Vercel logs
+          if (sub.status === "active" && sub.stripeSubscriptionId) {
+            try {
+              await stripeClient.subscriptions.cancel(sub.stripeSubscriptionId);
+            } catch (error) {
+              console.error(
+                `[BILLING ALERT] Stripe cancellation failed after DB delete for user ${user.id}. ` +
+                  `Stripe subscription ${sub.stripeSubscriptionId} requires manual cancellation.`,
+                error,
+              );
+            }
+          }
         }
         // Delete corresponding Strapi member record.
         try {


### PR DESCRIPTION
- Added separate try-catch blocks for Supabase subscription row deletion and Strapi subscription cancellation
- Order switched, now if DB deletion fails first (which is probably more likely to fail than Strapi uptime), user can try again
- If DB deletion succeeds and Stripe cancellation fails, admins can manually cancel subscription. A custom err alert prefixed with [BILLING ALERT] will show in Vercel logs 

This is probably better than the original order because:
1. Less probability of one operation succeeding and the other failing (if we let the Supabase-level operation happen first)
2. If manual intervention is needed, admins would have an easier time finding the subscription needed to be erased in Stripe dashboard rather than crawling through Supabase table rows