### PR TITLE
Enable Strapi MCP in CMS server config

### DIFF
--- a/joca-cms/config/server.ts
+++ b/joca-cms/config/server.ts
@@ -1,11 +1,18 @@
-export default ({ env }) => {
-  const webhookSecret = env('STRAPI_WEBHOOK_SECRET', '');
+import type { Core } from "@strapi/strapi";
+
+const config = ({
+  env,
+}: Core.Config.Shared.ConfigParams): Core.Config.Server => {
+  const webhookSecret = env("STRAPI_WEBHOOK_SECRET", "");
 
   return {
-    host: env('HOST', '0.0.0.0'),
-    port: env.int('PORT', 1337),
+    host: env("HOST", "0.0.0.0"),
+    port: env.int("PORT", 1337),
     app: {
-      keys: env.array('APP_KEYS'),
+      keys: env.array("APP_KEYS"),
+    },
+    mcp: {
+      enabled: true,
     },
     ...(webhookSecret
       ? {
@@ -18,3 +25,5 @@ export default ({ env }) => {
       : {}),
   };
 };
+
+export default config;

--- a/joca-cms/pnpm-lock.yaml
+++ b/joca-cms/pnpm-lock.yaml
@@ -2548,9 +2548,6 @@ packages:
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
-  '@types/node@24.10.10':
-    resolution: {integrity: sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==}
-
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
@@ -2584,9 +2581,6 @@ packages:
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
       '@types/react': '*'
-
-  '@types/react@18.3.27':
-    resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
 
   '@types/react@18.3.31':
     resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
@@ -6455,9 +6449,6 @@ packages:
   undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -7844,7 +7835,7 @@ snapshots:
 
   '@lazy-node/types-path@1.0.3(ts-toolbelt@9.6.0)':
     dependencies:
-      '@types/node': 24.10.10
+      '@types/node': 24.13.3
       ts-type: 3.0.13(ts-toolbelt@9.6.0)
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -10135,7 +10126,7 @@ snapshots:
 
   '@types/accepts@1.3.7':
     dependencies:
-      '@types/node': 24.10.10
+      '@types/node': 24.13.3
 
   '@types/argparse@1.0.38': {}
 
@@ -10148,7 +10139,7 @@ snapshots:
 
   '@types/co-body@6.1.3':
     dependencies:
-      '@types/node': 24.10.10
+      '@types/node': 24.13.3
       '@types/qs': 6.15.0
 
   '@types/connect@3.4.38':
@@ -10162,7 +10153,7 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/express': 5.0.6
       '@types/keygrip': 1.0.6
-      '@types/node': 24.10.10
+      '@types/node': 24.13.3
 
   '@types/debug@4.1.13':
     dependencies:
@@ -10193,7 +10184,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 24.10.10
+      '@types/node': 24.13.3
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -10219,16 +10210,11 @@ snapshots:
 
   '@types/formidable@2.0.6':
     dependencies:
-      '@types/node': 24.10.10
+      '@types/node': 24.13.3
 
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/hoist-non-react-statics@3.3.7(@types/react@18.3.27)':
-    dependencies:
-      '@types/react': 18.3.27
-      hoist-non-react-statics: 3.3.2
 
   '@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31)':
     dependencies:
@@ -10270,7 +10256,7 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/keygrip': 1.0.6
       '@types/koa-compose': 3.2.9
-      '@types/node': 24.10.10
+      '@types/node': 24.13.3
 
   '@types/liftoff@4.0.3':
     dependencies:
@@ -10293,10 +10279,6 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
       form-data: 4.0.5
-
-  '@types/node@24.10.10':
-    dependencies:
-      undici-types: 7.16.0
 
   '@types/node@24.13.3':
     dependencies:
@@ -10326,11 +10308,6 @@ snapshots:
     dependencies:
       '@types/react': 18.3.31
 
-  '@types/react@18.3.27':
-    dependencies:
-      '@types/prop-types': 15.7.15
-      csstype: 3.2.3
-
   '@types/react@18.3.31':
     dependencies:
       '@types/prop-types': 15.7.15
@@ -10354,7 +10331,7 @@ snapshots:
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 24.10.10
+      '@types/node': 24.13.3
 
   '@types/through@0.0.33':
     dependencies:
@@ -13670,8 +13647,8 @@ snapshots:
       '@formatjs/intl': 2.10.0(typescript@5.9.3)
       '@formatjs/intl-displaynames': 6.6.6
       '@formatjs/intl-listformat': 7.5.5
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.27)
-      '@types/react': 18.3.27
+      '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.31)
+      '@types/react': 18.3.31
       hoist-non-react-statics: 3.3.2
       intl-messageformat: 10.5.11
       react: 18.3.1
@@ -14528,7 +14505,7 @@ snapshots:
 
   ts-type@3.0.13(ts-toolbelt@9.6.0):
     dependencies:
-      '@types/node': 24.10.10
+      '@types/node': 24.13.3
       ts-toolbelt: 9.6.0
       tslib: 2.8.1
       typedarray-dts: 1.0.0
@@ -14614,8 +14591,6 @@ snapshots:
 
   undefsafe@2.0.5: {}
 
-  undici-types@7.16.0: {}
-
   undici-types@7.18.2: {}
 
   undici@6.27.0: {}
@@ -14669,7 +14644,7 @@ snapshots:
   upath2@3.1.23(ts-toolbelt@9.6.0):
     dependencies:
       '@lazy-node/types-path': 1.0.3(ts-toolbelt@9.6.0)
-      '@types/node': 24.10.10
+      '@types/node': 24.13.3
       path-is-network-drive: 1.0.24
       path-strip-sep: 1.0.21
       tslib: 2.8.1

--- a/joca-cms/tsconfig.json
+++ b/joca-cms/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "Node",
     "lib": ["ES2020"],
     "target": "ES2019",
     "strict": false,


### PR DESCRIPTION
## Summary
- Enable Strapi MCP (`mcp.enabled`) in `joca-cms/config/server.ts` so agents can manage CMS content locally.
- Keep existing webhook Authorization header support while typing the server config with Strapi `Core` types.
- Include related CMS `tsconfig`/`pnpm-lock` updates from the stashed local MCP setup.

## Test plan
- [ ] Start `joca-cms` with `pnpm dev` and confirm MCP tools can list/update content
- [ ] Confirm webhook Authorization headers still apply when `STRAPI_WEBHOOK_SECRET` is set
- [ ] Confirm CMS still boots cleanly without that env var
