### PR TITLE
Require staff approval before Stripe membership checkout

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -50,6 +50,9 @@ Also rotate any shared student credentials after transfer.
   - `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`
   - `RESEND_API_KEY`, `JOCA_APPROVALS_EMAIL`
   - `JOCA_ETRANSFER_EMAIL` (optional; enables Interac e-Transfer instructions)
+  - `JOCA_ETRANSFER_SECURITY_QUESTION` / `JOCA_ETRANSFER_SECURITY_ANSWER` (optional; bolded in copy)
+  - `JOCA_ETRANSFER_INSTRUCTIONS` (optional freeform notes)
+  - `JOCA_ADMIN_EMAILS` (optional; staff dashboard allowlist, else `JOCA_APPROVALS_EMAIL`)
   - `STRAPI_GRAPHQL_URL`
 - **Do not set** `NEXT_PUBLIC_SKIP_EMAIL_VERIFICATION=true` in production.
 - After attaching a custom domain, update `BETTER_AUTH_URL` and `NEXT_PUBLIC_BETTER_AUTH_URL` to that origin (no trailing slash), then redeploy.
@@ -132,7 +135,14 @@ https://<YOUR_DOMAIN>/api/auth/stripe/webhook
 5. **Interac e-Transfer path (manual):** member sends e-Transfer to `JOCA_ETRANSFER_EMAIL` outside Stripe. Staff reopen the same review link and click **Mark Interac e-Transfer as received** → app activates a local `Subscription` (`billingInterval=etransfer`, no Stripe subscription) and syncs the Strapi Member. This will **not** appear in the Stripe Dashboard.
 6. Pending / approved-but-unpaid members can use Account / Sign Out; Elections nav is visible but the page stays payment-gated until an active subscription exists.
 
-Set `JOCA_APPROVALS_EMAIL` on Vercel when the inbox address is known. Set `JOCA_ETRANSFER_EMAIL` (and optional `JOCA_ETRANSFER_INSTRUCTIONS`) to enable e-Transfer copy in emails and on `/payment`.
+Set `JOCA_APPROVALS_EMAIL` on Vercel when the inbox address is known. Set `JOCA_ETRANSFER_EMAIL` (and optional `JOCA_ETRANSFER_SECURITY_QUESTION` / `JOCA_ETRANSFER_SECURITY_ANSWER` / `JOCA_ETRANSFER_INSTRUCTIONS`) to enable e-Transfer copy in emails and on `/payment`.
+
+**Staff applications dashboard**
+
+- URL: `/admin/applications`
+- Access: signed-in Better Auth users whose email is in `JOCA_ADMIN_EMAILS` (comma-separated), or `JOCA_APPROVALS_EMAIL` if the allowlist is unset.
+- Shows pending reviews and approved-but-unpaid members as cards (approve / reject / mark Interac received).
+- Header bell shows a badge with the count of applications needing attention (awaiting review + awaiting payment) for those admins.
 
 **Webhook events to subscribe:**
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -15,9 +15,9 @@ Env templates: [joca-app/.env.example](joca-app/.env.example) · [joca-cms/.env.
 | CMS (Strapi 5)      | `joca-cms/` → **Strapi Cloud**     | Events, elections, candidates, members     |
 | Auth / app database | **Supabase** Postgres (via Prisma) | Users, sessions, subscriptions, votes      |
 | Payments            | **Stripe**                         | Membership subscriptions + Customer Portal |
-| Email               | **Resend**                         | Email verification messages                |
+| Email               | **Resend**                         | Verification + membership approval emails  |
 
-Architecture note: login accounts live in Supabase/Prisma (Better Auth). **Member** records in Strapi are created after successful payment and used for elections/candidates. Do not treat Strapi Users & Permissions as the primary member login system.
+Architecture note: login accounts live in Supabase/Prisma (Better Auth). New signups are staff-approved before Stripe payment. **Member** records in Strapi are created after successful payment and used for elections/candidates. Do not treat Strapi Users & Permissions as the primary member login system.
 
 ---
 
@@ -48,7 +48,7 @@ Also rotate any shared student credentials after transfer.
   - `DATABASE_URL`, `DIRECT_URL`
   - `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `NEXT_PUBLIC_BETTER_AUTH_URL`
   - `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`
-  - `RESEND_API_KEY`
+  - `RESEND_API_KEY`, `JOCA_APPROVALS_EMAIL`
   - `STRAPI_GRAPHQL_URL`
 - **Do not set** `NEXT_PUBLIC_SKIP_EMAIL_VERIFICATION=true` in production.
 - After attaching a custom domain, update `BETTER_AUTH_URL` and `NEXT_PUBLIC_BETTER_AUTH_URL` to that origin (no trailing slash), then redeploy.
@@ -122,6 +122,16 @@ https://<YOUR_DOMAIN>/api/auth/stripe/webhook
 | Family              | `family-membership`            |
 | Student / associate | `student-associate-membership` |
 
+**Membership approval flow**
+
+1. Member signs up (suggests a plan) and verifies email.
+2. App emails `JOCA_APPROVALS_EMAIL` with applicant details + a signed review link (`/admin/approve-membership?token=…`, ~7 day expiry).
+3. Staff pick/override the plan and **Approve** → app creates a Stripe Checkout Session and Resend-emails the payment link to the member. **Reject** notifies the member and blocks payment.
+4. After payment, Better Auth Stripe webhooks activate `Subscription`; Elections + Manage membership unlock.
+5. Pending members can use Account / Sign Out only (no Elections nav, no Manage membership).
+
+Set `JOCA_APPROVALS_EMAIL` on Vercel when the inbox address is known.
+
 **Webhook events to subscribe:**
 
 - `checkout.session.completed`
@@ -137,13 +147,13 @@ https://<YOUR_DOMAIN>/api/auth/stripe/webhook
 4. Set `STRIPE_SECRET_KEY` on Vercel (`sk_test_…` vs `sk_live_…`).
 5. Local forwarding: `stripe listen --forward-to localhost:3000/api/auth/stripe/webhook`.
 
-Billing portal and checkout are already wired in the app UI. No Stripe Connect.
+Billing portal and checkout are wired in the app UI. Checkout links for new members are also created on staff approval. No Stripe Connect.
 
 ### 3.5 Resend (email)
 
-- Used for **email verification** only (no password-reset flow in the product yet).
+- Used for **email verification**, **staff membership-application notices**, and **member approve/reject + payment link** emails (no password-reset flow in the product yet).
 - Production still needs a verified JOCA domain and a real `from` address.
-- Code currently sends from `onboarding@resend.dev` (`joca-app/src/lib/auth.ts`) — replace after DNS verification in Resend.
-- Set `RESEND_API_KEY` on Vercel; keep it unset only for local work that also skips verification.
+- Code currently sends from `onboarding@resend.dev` (`joca-app/src/lib/resend.ts`) — replace after DNS verification in Resend.
+- Set `RESEND_API_KEY` and `JOCA_APPROVALS_EMAIL` on Vercel; keep Resend unset only for local work that also skips verification (approve URLs are logged to the server console when Resend is missing).
 
 ---

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -49,6 +49,7 @@ Also rotate any shared student credentials after transfer.
   - `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `NEXT_PUBLIC_BETTER_AUTH_URL`
   - `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`
   - `RESEND_API_KEY`, `JOCA_APPROVALS_EMAIL`
+  - `JOCA_ETRANSFER_EMAIL` (optional; enables Interac e-Transfer instructions)
   - `STRAPI_GRAPHQL_URL`
 - **Do not set** `NEXT_PUBLIC_SKIP_EMAIL_VERIFICATION=true` in production.
 - After attaching a custom domain, update `BETTER_AUTH_URL` and `NEXT_PUBLIC_BETTER_AUTH_URL` to that origin (no trailing slash), then redeploy.
@@ -125,12 +126,13 @@ https://<YOUR_DOMAIN>/api/auth/stripe/webhook
 **Membership approval flow**
 
 1. Member signs up (suggests a plan) and verifies email.
-2. App emails `JOCA_APPROVALS_EMAIL` with applicant details + a signed review link (`/admin/approve-membership?token=…`, ~7 day expiry).
-3. Staff pick/override the plan and **Approve** → app creates a Stripe Checkout Session and Resend-emails the payment link to the member. **Reject** notifies the member and blocks payment.
-4. After payment, Better Auth Stripe webhooks activate `Subscription`; Elections + Manage membership unlock.
-5. Pending members can use Account / Sign Out only (no Elections nav, no Manage membership).
+2. App emails `JOCA_APPROVALS_EMAIL` with applicant details + a signed review link (`/admin/approve-membership?token=…`, ~30 day expiry).
+3. Staff pick/override the plan and **Approve** → app creates a Stripe Checkout Session and Resend-emails the member with card payment + (optional) Interac e-Transfer instructions. **Reject** notifies the member and blocks payment.
+4. **Card path:** member pays via Stripe → Better Auth Stripe webhooks activate `Subscription` → Elections unlock; **Manage membership** (Customer Portal) appears when a Stripe subscription id exists.
+5. **Interac e-Transfer path (manual):** member sends e-Transfer to `JOCA_ETRANSFER_EMAIL` outside Stripe. Staff reopen the same review link and click **Mark Interac e-Transfer as received** → app activates a local `Subscription` (`billingInterval=etransfer`, no Stripe subscription) and syncs the Strapi Member. This will **not** appear in the Stripe Dashboard.
+6. Pending / approved-but-unpaid members can use Account / Sign Out; Elections nav is visible but the page stays payment-gated until an active subscription exists.
 
-Set `JOCA_APPROVALS_EMAIL` on Vercel when the inbox address is known.
+Set `JOCA_APPROVALS_EMAIL` on Vercel when the inbox address is known. Set `JOCA_ETRANSFER_EMAIL` (and optional `JOCA_ETRANSFER_INSTRUCTIONS`) to enable e-Transfer copy in emails and on `/payment`.
 
 **Webhook events to subscribe:**
 

--- a/joca-app/.env.example
+++ b/joca-app/.env.example
@@ -29,6 +29,11 @@ RESEND_API_KEY="re_..."
 # Inbox that receives new membership applications (staff approve via emailed link).
 # Required for the approval notify flow; TBD until JOCA provides the address.
 JOCA_APPROVALS_EMAIL="approvals@example.com"
+# Interac e-Transfer destination shown to approved members (optional).
+# When set, approval emails and /payment include e-Transfer instructions.
+JOCA_ETRANSFER_EMAIL="memberships@example.com"
+# Optional freeform notes (security question, amount guidance, etc.)
+# JOCA_ETRANSFER_INSTRUCTIONS="Use security question: JOCA / answer: … Include your full name in the message."
 
 # --- Strapi CMS GraphQL ---
 # Local default is http://localhost:1337/graphql when NODE_ENV=development

--- a/joca-app/.env.example
+++ b/joca-app/.env.example
@@ -23,9 +23,12 @@ STRIPE_SECRET_KEY="sk_test_..."
 # Required in production (NODE_ENV !== development)
 STRIPE_WEBHOOK_SECRET="whsec_..."
 
-# --- Resend (email verification) ---
+# --- Resend (email verification + membership approval emails) ---
 # Required in production. Optional locally if you skip verification (see below).
 RESEND_API_KEY="re_..."
+# Inbox that receives new membership applications (staff approve via emailed link).
+# Required for the approval notify flow; TBD until JOCA provides the address.
+JOCA_APPROVALS_EMAIL="approvals@example.com"
 
 # --- Strapi CMS GraphQL ---
 # Local default is http://localhost:1337/graphql when NODE_ENV=development

--- a/joca-app/.env.example
+++ b/joca-app/.env.example
@@ -29,11 +29,17 @@ RESEND_API_KEY="re_..."
 # Inbox that receives new membership applications (staff approve via emailed link).
 # Required for the approval notify flow; TBD until JOCA provides the address.
 JOCA_APPROVALS_EMAIL="approvals@example.com"
+# Comma-separated Better Auth emails that can open /admin/applications and see
+# the applications notification counter (pending review + awaiting payment). Falls back to JOCA_APPROVALS_EMAIL.
+# JOCA_ADMIN_EMAILS="board@example.com,treasurer@example.com"
 # Interac e-Transfer destination shown to approved members (optional).
 # When set, approval emails and /payment include e-Transfer instructions.
 JOCA_ETRANSFER_EMAIL="memberships@example.com"
-# Optional freeform notes (security question, amount guidance, etc.)
-# JOCA_ETRANSFER_INSTRUCTIONS="Use security question: JOCA / answer: … Include your full name in the message."
+# Optional Interac security question/answer (rendered bold in emails and /payment).
+# JOCA_ETRANSFER_SECURITY_QUESTION="JOCA"
+# JOCA_ETRANSFER_SECURITY_ANSWER="…"
+# Optional freeform notes appended after the security line.
+# JOCA_ETRANSFER_INSTRUCTIONS="Include your full name in the message."
 
 # --- Strapi CMS GraphQL ---
 # Local default is http://localhost:1337/graphql when NODE_ENV=development

--- a/joca-app/prisma/migrations/20260731220000_add_membership_approval_fields/migration.sql
+++ b/joca-app/prisma/migrations/20260731220000_add_membership_approval_fields/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN "requestedPlan" TEXT,
+ADD COLUMN "approvedPlan" TEXT,
+ADD COLUMN "membershipStatus" TEXT NOT NULL DEFAULT 'pending_approval';
+
+-- Backfill existing paid members so they stay "approved"
+UPDATE "user" AS u
+SET
+  "membershipStatus" = 'approved',
+  "approvedPlan" = s.plan
+FROM "subscription" AS s
+WHERE s."referenceId" = u.id
+  AND s.status = 'active';

--- a/joca-app/prisma/migrations/20260801010000_subscription_user_fk_cascade/migration.sql
+++ b/joca-app/prisma/migrations/20260801010000_subscription_user_fk_cascade/migration.sql
@@ -1,0 +1,11 @@
+-- Remove orphaned subscription rows (no matching user) before adding the FK.
+DELETE FROM "subscription" AS s
+WHERE NOT EXISTS (
+  SELECT 1 FROM "user" AS u WHERE u.id = s."referenceId"
+);
+
+-- Cascade-delete subscriptions (including Interac e-Transfer rows) when the user is deleted.
+ALTER TABLE "subscription"
+ADD CONSTRAINT "subscription_referenceId_fkey"
+FOREIGN KEY ("referenceId") REFERENCES "user"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/joca-app/prisma/schema.prisma
+++ b/joca-app/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   sessions      Session[]
   accounts      Account[]
   votes         Vote[]
+  subscription  Subscription?
 
   stripeCustomerId String?
 
@@ -103,6 +104,7 @@ model Subscription {
   id                   String    @id
   plan                 String
   referenceId          String
+  user                 User      @relation(fields: [referenceId], references: [id], onDelete: Cascade)
   stripeCustomerId     String?
   stripeSubscriptionId String?
   status               String

--- a/joca-app/prisma/schema.prisma
+++ b/joca-app/prisma/schema.prisma
@@ -25,6 +25,13 @@ model User {
 
   stripeCustomerId String?
 
+  /// Member-suggested plan at signup (Stripe lookup key / plan id)
+  requestedPlan String?
+  /// Staff-chosen plan when approving (Stripe lookup key / plan id)
+  approvedPlan String?
+  /// pending_approval | approved | rejected
+  membershipStatus String @default("pending_approval")
+
   @@unique([email])
   @@map("user")
 }

--- a/joca-app/src/app/admin/applications/ApplicationCard.tsx
+++ b/joca-app/src/app/admin/applications/ApplicationCard.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  MEMBERSHIP_PLANS,
+  MEMBERSHIP_STATUS,
+  getPlanLabel,
+  getMembershipStatusLabel,
+} from "@/lib/membership-plans";
+import {
+  adminApproveApplicationAction,
+  adminConfirmEtransferAction,
+  adminRejectApplicationAction,
+} from "./actions";
+
+type ConfirmAction = "approve" | "reject";
+
+export type ApplicationCardData = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+  requestedPlan: string | null;
+  approvedPlan: string | null;
+  membershipStatus: string;
+  createdAt: string;
+  hasActiveSubscription: boolean;
+};
+
+export function ApplicationCard({
+  applicant,
+  etransferEnabled,
+}: {
+  applicant: ApplicationCardData;
+  etransferEnabled: boolean;
+}) {
+  const [planId, setPlanId] = useState(
+    applicant.approvedPlan ||
+      applicant.requestedPlan ||
+      MEMBERSHIP_PLANS[0].id,
+  );
+  const [status, setStatus] = useState(applicant.membershipStatus);
+  const [paid, setPaid] = useState(applicant.hasActiveSubscription);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction>("approve");
+  const [isPending, startTransition] = useTransition();
+  const applicantName = `${applicant.firstName} ${applicant.lastName}`;
+
+  const openConfirm = (action: ConfirmAction) => {
+    setConfirmAction(action);
+    setConfirmOpen(true);
+  };
+
+  const pendingReview = status === MEMBERSHIP_STATUS.PENDING_APPROVAL;
+  const awaitingPayment =
+    !paid && status === MEMBERSHIP_STATUS.APPROVED;
+
+  const runAction = (
+    action: () => Promise<{ ok: boolean; message: string }>,
+    onOk: () => void,
+  ) => {
+    setError(null);
+    setMessage(null);
+    startTransition(async () => {
+      const result = await action();
+      if (result.ok) {
+        onOk();
+        setMessage(result.message);
+      } else {
+        setError(result.message);
+      }
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">
+          {applicant.firstName} {applicant.lastName}
+        </CardTitle>
+        <CardDescription>
+          Applied {new Date(applicant.createdAt).toLocaleString()}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <dl className="space-y-2">
+          <div>
+            <dt className="text-muted-foreground">Email</dt>
+            <dd className="font-medium break-all">{applicant.email}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Phone</dt>
+            <dd className="font-medium">{applicant.phoneNumber}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Requested plan</dt>
+            <dd className="font-medium">
+              {getPlanLabel(applicant.requestedPlan)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Status</dt>
+            <dd className="font-medium">{getMembershipStatusLabel(status)}</dd>
+          </div>
+          {status === MEMBERSHIP_STATUS.APPROVED && (
+            <div>
+              <dt className="text-muted-foreground">Approved plan</dt>
+              <dd className="font-medium">{getPlanLabel(planId)}</dd>
+            </div>
+          )}
+        </dl>
+
+        {pendingReview && (
+          <div className="space-y-2">
+            <Label htmlFor={`plan-${applicant.id}`}>
+              Membership type to approve
+            </Label>
+            <Select
+              value={planId}
+              onValueChange={setPlanId}
+              disabled={isPending}
+            >
+              <SelectTrigger id={`plan-${applicant.id}`} className="w-full">
+                <SelectValue placeholder="Select a membership type" />
+              </SelectTrigger>
+              <SelectContent>
+                {MEMBERSHIP_PLANS.map((plan) => (
+                  <SelectItem key={plan.id} value={plan.id}>
+                    {plan.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+        {message && (
+          <p className="text-sm text-green-700 dark:text-green-400">{message}</p>
+        )}
+      </CardContent>
+      <CardFooter className="flex flex-col gap-2 sm:flex-row">
+        {pendingReview && (
+          <>
+            <Button
+              className="flex-1"
+              disabled={isPending}
+              onClick={() => openConfirm("approve")}
+            >
+              {isPending ? "Working..." : "Approve"}
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-1"
+              disabled={isPending}
+              onClick={() => openConfirm("reject")}
+            >
+              Reject
+            </Button>
+          </>
+        )}
+        {awaitingPayment && etransferEnabled && (
+          <Button
+            className="w-full"
+            disabled={isPending}
+            onClick={() => {
+              const fd = new FormData();
+              fd.set("userId", applicant.id);
+              runAction(
+                () => adminConfirmEtransferAction(fd),
+                () => setPaid(true),
+              );
+            }}
+          >
+            {isPending ? "Working..." : "Mark Interac e-Transfer received"}
+          </Button>
+        )}
+        {awaitingPayment && !etransferEnabled && (
+          <p className="text-sm text-muted-foreground">
+            Waiting for the member to complete card payment.
+          </p>
+        )}
+        {paid && (
+          <p className="text-sm text-muted-foreground">Membership is active.</p>
+        )}
+        {status === MEMBERSHIP_STATUS.REJECTED && !message && (
+          <p className="text-sm text-muted-foreground">Application rejected.</p>
+        )}
+      </CardFooter>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {confirmAction === "approve"
+                ? "Approve this application?"
+                : "Reject this application?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmAction === "approve" ? (
+                <>
+                  Approve {applicantName} for{" "}
+                  <strong>{getPlanLabel(planId)}</strong>? They will be emailed
+                  payment options.
+                </>
+              ) : (
+                <>
+                  Reject {applicantName}&apos;s application? They will be
+                  notified by email. This cannot be undone from this screen.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant={confirmAction === "reject" ? "destructive" : "default"}
+              disabled={isPending}
+              onClick={() => {
+                if (confirmAction === "approve") {
+                  const fd = new FormData();
+                  fd.set("userId", applicant.id);
+                  fd.set("planId", planId);
+                  runAction(
+                    () => adminApproveApplicationAction(fd),
+                    () => setStatus(MEMBERSHIP_STATUS.APPROVED),
+                  );
+                } else {
+                  const fd = new FormData();
+                  fd.set("userId", applicant.id);
+                  runAction(
+                    () => adminRejectApplicationAction(fd),
+                    () => setStatus(MEMBERSHIP_STATUS.REJECTED),
+                  );
+                }
+                setConfirmOpen(false);
+              }}
+            >
+              {confirmAction === "approve" ? "Approve" : "Reject"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/joca-app/src/app/admin/applications/actions.ts
+++ b/joca-app/src/app/admin/applications/actions.ts
@@ -1,0 +1,112 @@
+"use server";
+
+import { headers } from "next/headers";
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+import { isJocaAdminEmail } from "@/lib/joca-admin";
+import {
+  approveMembershipApplication,
+  confirmEtransferPayment,
+  rejectMembershipApplication,
+} from "@/lib/membership-checkout";
+import { isMembershipPlanId } from "@/lib/membership-plans";
+
+export type AdminActionResult =
+  | { ok: true; message: string }
+  | { ok: false; message: string };
+
+async function requireAdmin(): Promise<
+  { ok: true } | { ok: false; message: string }
+> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) {
+    return { ok: false, message: "You must be signed in." };
+  }
+  if (!isJocaAdminEmail(session.user.email)) {
+    return { ok: false, message: "You are not authorized to manage applications." };
+  }
+  return { ok: true };
+}
+
+export async function adminApproveApplicationAction(
+  formData: FormData,
+): Promise<AdminActionResult> {
+  const gate = await requireAdmin();
+  if (!gate.ok) return gate;
+
+  const userId = String(formData.get("userId") ?? "");
+  const planId = String(formData.get("planId") ?? "");
+
+  if (!userId) return { ok: false, message: "Missing applicant id." };
+  if (!isMembershipPlanId(planId)) {
+    return { ok: false, message: "Please select a valid membership plan." };
+  }
+
+  try {
+    await approveMembershipApplication({ userId, planId });
+    revalidatePath("/admin/applications");
+    return {
+      ok: true,
+      message:
+        "Application approved. Payment options have been emailed to the member.",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message:
+        error instanceof Error ? error.message : "Failed to approve application.",
+    };
+  }
+}
+
+export async function adminRejectApplicationAction(
+  formData: FormData,
+): Promise<AdminActionResult> {
+  const gate = await requireAdmin();
+  if (!gate.ok) return gate;
+
+  const userId = String(formData.get("userId") ?? "");
+  if (!userId) return { ok: false, message: "Missing applicant id." };
+
+  try {
+    await rejectMembershipApplication({ userId });
+    revalidatePath("/admin/applications");
+    return {
+      ok: true,
+      message: "Application rejected. The member has been notified.",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message:
+        error instanceof Error ? error.message : "Failed to reject application.",
+    };
+  }
+}
+
+export async function adminConfirmEtransferAction(
+  formData: FormData,
+): Promise<AdminActionResult> {
+  const gate = await requireAdmin();
+  if (!gate.ok) return gate;
+
+  const userId = String(formData.get("userId") ?? "");
+  if (!userId) return { ok: false, message: "Missing applicant id." };
+
+  try {
+    await confirmEtransferPayment({ userId });
+    revalidatePath("/admin/applications");
+    return {
+      ok: true,
+      message: "Interac e-Transfer confirmed. Membership is active.",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message:
+        error instanceof Error
+          ? error.message
+          : "Failed to confirm e-Transfer payment.",
+    };
+  }
+}

--- a/joca-app/src/app/admin/applications/page.tsx
+++ b/joca-app/src/app/admin/applications/page.tsx
@@ -1,0 +1,127 @@
+import { Suspense } from "react";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { isJocaAdminEmail } from "@/lib/joca-admin";
+import { MEMBERSHIP_STATUS } from "@/lib/membership-plans";
+import { getEtransferInstructions } from "@/lib/membership-etransfer";
+import { ApplicationCard } from "./ApplicationCard";
+import Loading from "@/app/loading";
+
+async function ApplicationsDashboard() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) redirect("/login");
+  if (!isJocaAdminEmail(session.user.email)) redirect("/");
+
+  const users = await prisma.user.findMany({
+    where: {
+      emailVerified: true,
+      OR: [
+        { membershipStatus: MEMBERSHIP_STATUS.PENDING_APPROVAL },
+        { membershipStatus: MEMBERSHIP_STATUS.APPROVED },
+      ],
+    },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+      phoneNumber: true,
+      requestedPlan: true,
+      approvedPlan: true,
+      membershipStatus: true,
+      createdAt: true,
+    },
+  });
+
+  const activeSubs = await prisma.subscription.findMany({
+    where: {
+      referenceId: { in: users.map((u) => u.id) },
+      status: "active",
+    },
+    select: { referenceId: true },
+  });
+  const activeUserIds = new Set(activeSubs.map((s) => s.referenceId));
+
+  const applicants = users
+    .map((user) => ({
+      id: user.id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      email: user.email,
+      phoneNumber: user.phoneNumber,
+      requestedPlan: user.requestedPlan,
+      approvedPlan: user.approvedPlan,
+      membershipStatus: user.membershipStatus,
+      createdAt: user.createdAt.toISOString(),
+      hasActiveSubscription: activeUserIds.has(user.id),
+    }))
+    .filter(
+      (user) =>
+        user.membershipStatus === MEMBERSHIP_STATUS.PENDING_APPROVAL ||
+        (user.membershipStatus === MEMBERSHIP_STATUS.APPROVED &&
+          !user.hasActiveSubscription),
+    );
+
+  const pendingCount = applicants.filter(
+    (a) => a.membershipStatus === MEMBERSHIP_STATUS.PENDING_APPROVAL,
+  ).length;
+  const awaitingPaymentCount = applicants.filter(
+    (a) => a.membershipStatus === MEMBERSHIP_STATUS.APPROVED,
+  ).length;
+
+  const etransferEnabled = Boolean(getEtransferInstructions());
+
+  return (
+    <div
+      className={
+        applicants.length === 1
+          ? "container mx-auto max-w-lg space-y-8 p-8"
+          : "container mx-auto max-w-5xl space-y-8 p-8"
+      }
+    >
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">Membership applications</h1>
+        <p className="text-muted-foreground">
+          Review pending signups and confirm Interac e-Transfer payments.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          {pendingCount} awaiting review
+          {awaitingPaymentCount > 0
+            ? ` · ${awaitingPaymentCount} awaiting payment`
+            : ""}
+        </p>
+      </header>
+
+      {applicants.length === 0 ? (
+        <p className="text-muted-foreground">
+          No applications need attention right now.
+        </p>
+      ) : (
+        <div
+          className={
+            applicants.length === 1 ? undefined : "grid gap-6 md:grid-cols-2"
+          }
+        >
+          {applicants.map((applicant) => (
+            <ApplicationCard
+              key={applicant.id}
+              applicant={applicant}
+              etransferEnabled={etransferEnabled}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function AdminApplicationsPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <ApplicationsDashboard />
+    </Suspense>
+  );
+}

--- a/joca-app/src/app/admin/approve-membership/ApproveMembershipForm.tsx
+++ b/joca-app/src/app/admin/approve-membership/ApproveMembershipForm.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { MEMBERSHIP_PLANS, getPlanLabel } from "@/lib/membership-plans";
+import {
+  approveMembershipAction,
+  rejectMembershipAction,
+} from "./actions";
+
+type Applicant = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+  requestedPlan: string | null;
+  membershipStatus: string;
+  approvedPlan: string | null;
+};
+
+export function ApproveMembershipForm({
+  token,
+  applicant,
+  hasActiveSubscription,
+}: {
+  token: string;
+  applicant: Applicant;
+  hasActiveSubscription: boolean;
+}) {
+  const [planId, setPlanId] = useState(
+    applicant.approvedPlan ||
+      applicant.requestedPlan ||
+      MEMBERSHIP_PLANS[0].id,
+  );
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  if (hasActiveSubscription) {
+    return (
+      <Card className="w-full max-w-xl mx-auto my-12">
+        <CardHeader>
+          <CardTitle>Already a member</CardTitle>
+          <CardDescription>
+            {applicant.firstName} {applicant.lastName} already has an active
+            membership. No further action is needed.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="w-full max-w-xl mx-auto my-12">
+      <CardHeader>
+        <CardTitle>Review membership application</CardTitle>
+        <CardDescription>
+          Confirm or change the membership type, then approve to email a Stripe
+          payment link to the member.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <dl className="space-y-2 text-sm">
+          <div>
+            <dt className="text-muted-foreground">Name</dt>
+            <dd className="font-medium">
+              {applicant.firstName} {applicant.lastName}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Email</dt>
+            <dd className="font-medium">{applicant.email}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Phone</dt>
+            <dd className="font-medium">{applicant.phoneNumber}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Requested plan</dt>
+            <dd className="font-medium">
+              {getPlanLabel(applicant.requestedPlan)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Current status</dt>
+            <dd className="font-medium">{applicant.membershipStatus}</dd>
+          </div>
+        </dl>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="planId">Membership type to approve</Label>
+            <select
+              id="planId"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={planId}
+              onChange={(e) => setPlanId(e.target.value)}
+              disabled={isPending}
+            >
+              {MEMBERSHIP_PLANS.map((plan) => (
+                <option key={plan.id} value={plan.id}>
+                  {plan.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {message && (
+            <p className="text-sm text-green-700 dark:text-green-400">
+              {message}
+            </p>
+          )}
+          {error && (
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          )}
+
+          <div className="flex flex-col sm:flex-row gap-3">
+            <Button
+              type="button"
+              className="flex-1"
+              disabled={isPending}
+              onClick={() => {
+                setError(null);
+                setMessage(null);
+                const fd = new FormData();
+                fd.set("token", token);
+                fd.set("planId", planId);
+                startTransition(async () => {
+                  const result = await approveMembershipAction(fd);
+                  if (result.ok) setMessage(result.message);
+                  else setError(result.message);
+                });
+              }}
+            >
+              {isPending ? "Working..." : "Approve & email payment link"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1"
+              disabled={isPending}
+              onClick={() => {
+                setError(null);
+                setMessage(null);
+                const fd = new FormData();
+                fd.set("token", token);
+                startTransition(async () => {
+                  const result = await rejectMembershipAction(fd);
+                  if (result.ok) setMessage(result.message);
+                  else setError(result.message);
+                });
+              }}
+            >
+              Reject
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/joca-app/src/app/admin/approve-membership/ApproveMembershipForm.tsx
+++ b/joca-app/src/app/admin/approve-membership/ApproveMembershipForm.tsx
@@ -10,7 +10,19 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { MEMBERSHIP_PLANS, getPlanLabel } from "@/lib/membership-plans";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  MEMBERSHIP_PLANS,
+  MEMBERSHIP_STATUS,
+  getPlanLabel,
+  getMembershipStatusLabel,
+} from "@/lib/membership-plans";
 import {
   approveMembershipAction,
   rejectMembershipAction,
@@ -26,6 +38,13 @@ type Applicant = {
   approvedPlan: string | null;
 };
 
+function isDecidedStatus(status: string): boolean {
+  return (
+    status === MEMBERSHIP_STATUS.APPROVED ||
+    status === MEMBERSHIP_STATUS.REJECTED
+  );
+}
+
 export function ApproveMembershipForm({
   token,
   applicant,
@@ -40,9 +59,17 @@ export function ApproveMembershipForm({
       applicant.requestedPlan ||
       MEMBERSHIP_PLANS[0].id,
   );
-  const [message, setMessage] = useState<string | null>(null);
+  const [status, setStatus] = useState(applicant.membershipStatus);
+  const [message, setMessage] = useState<string | null>(
+    isDecidedStatus(applicant.membershipStatus)
+      ? "This application has already been decided. No further action is needed."
+      : null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+
+  const decided = isDecidedStatus(status);
+  const controlsDisabled = isPending || decided;
 
   if (hasActiveSubscription) {
     return (
@@ -63,8 +90,9 @@ export function ApproveMembershipForm({
       <CardHeader>
         <CardTitle>Review membership application</CardTitle>
         <CardDescription>
-          Confirm or change the membership type, then approve to email a Stripe
-          payment link to the member.
+          {decided
+            ? "This application has already been reviewed."
+            : "Confirm or change the membership type, then approve to email a Stripe payment link to the member."}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -91,78 +119,96 @@ export function ApproveMembershipForm({
           </div>
           <div>
             <dt className="text-muted-foreground">Current status</dt>
-            <dd className="font-medium">{applicant.membershipStatus}</dd>
+            <dd className="font-medium">{getMembershipStatusLabel(status)}</dd>
           </div>
+          {status === MEMBERSHIP_STATUS.APPROVED && (
+            <div>
+              <dt className="text-muted-foreground">Approved plan</dt>
+              <dd className="font-medium">{getPlanLabel(planId)}</dd>
+            </div>
+          )}
         </dl>
 
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="planId">Membership type to approve</Label>
-            <select
-              id="planId"
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-              value={planId}
-              onChange={(e) => setPlanId(e.target.value)}
-              disabled={isPending}
-            >
-              {MEMBERSHIP_PLANS.map((plan) => (
-                <option key={plan.id} value={plan.id}>
-                  {plan.label}
-                </option>
-              ))}
-            </select>
-          </div>
+        {!decided && (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="planId">Membership type to approve</Label>
+              <Select
+                value={planId}
+                onValueChange={setPlanId}
+                disabled={controlsDisabled}
+              >
+                <SelectTrigger id="planId" className="w-full">
+                  <SelectValue placeholder="Select a membership type" />
+                </SelectTrigger>
+                <SelectContent>
+                  {MEMBERSHIP_PLANS.map((plan) => (
+                    <SelectItem key={plan.id} value={plan.id}>
+                      {plan.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
 
-          {message && (
-            <p className="text-sm text-green-700 dark:text-green-400">
-              {message}
-            </p>
-          )}
-          {error && (
-            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
-          )}
+            {error && (
+              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            )}
 
-          <div className="flex flex-col sm:flex-row gap-3">
-            <Button
-              type="button"
-              className="flex-1"
-              disabled={isPending}
-              onClick={() => {
-                setError(null);
-                setMessage(null);
-                const fd = new FormData();
-                fd.set("token", token);
-                fd.set("planId", planId);
-                startTransition(async () => {
-                  const result = await approveMembershipAction(fd);
-                  if (result.ok) setMessage(result.message);
-                  else setError(result.message);
-                });
-              }}
-            >
-              {isPending ? "Working..." : "Approve & email payment link"}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              className="flex-1"
-              disabled={isPending}
-              onClick={() => {
-                setError(null);
-                setMessage(null);
-                const fd = new FormData();
-                fd.set("token", token);
-                startTransition(async () => {
-                  const result = await rejectMembershipAction(fd);
-                  if (result.ok) setMessage(result.message);
-                  else setError(result.message);
-                });
-              }}
-            >
-              Reject
-            </Button>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <Button
+                type="button"
+                className="flex-1"
+                disabled={controlsDisabled}
+                onClick={() => {
+                  setError(null);
+                  setMessage(null);
+                  const fd = new FormData();
+                  fd.set("token", token);
+                  fd.set("planId", planId);
+                  startTransition(async () => {
+                    const result = await approveMembershipAction(fd);
+                    if (result.ok) {
+                      setStatus(MEMBERSHIP_STATUS.APPROVED);
+                      setMessage(result.message);
+                    } else {
+                      setError(result.message);
+                    }
+                  });
+                }}
+              >
+                {isPending ? "Working..." : "Approve & email payment link"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="flex-1"
+                disabled={controlsDisabled}
+                onClick={() => {
+                  setError(null);
+                  setMessage(null);
+                  const fd = new FormData();
+                  fd.set("token", token);
+                  startTransition(async () => {
+                    const result = await rejectMembershipAction(fd);
+                    if (result.ok) {
+                      setStatus(MEMBERSHIP_STATUS.REJECTED);
+                      setMessage(result.message);
+                    } else {
+                      setError(result.message);
+                    }
+                  });
+                }}
+              >
+                Reject
+              </Button>
+            </div>
           </div>
-        </div>
+        )}
+
+        {message && (
+          <p className="text-sm text-green-700 dark:text-green-400">{message}</p>
+        )}
       </CardContent>
     </Card>
   );

--- a/joca-app/src/app/admin/approve-membership/ApproveMembershipForm.tsx
+++ b/joca-app/src/app/admin/approve-membership/ApproveMembershipForm.tsx
@@ -18,6 +18,16 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
   MEMBERSHIP_PLANS,
   MEMBERSHIP_STATUS,
   getPlanLabel,
@@ -28,6 +38,8 @@ import {
   confirmEtransferAction,
   rejectMembershipAction,
 } from "./actions";
+
+type ConfirmAction = "approve" | "reject";
 
 type Applicant = {
   firstName: string;
@@ -79,7 +91,15 @@ export function ApproveMembershipForm({
     return null;
   });
   const [error, setError] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction>("approve");
   const [isPending, startTransition] = useTransition();
+  const applicantName = `${applicant.firstName} ${applicant.lastName}`;
+
+  const openConfirm = (action: ConfirmAction) => {
+    setConfirmAction(action);
+    setConfirmOpen(true);
+  };
 
   const decided = isDecidedStatus(status);
   const awaitingEtransfer =
@@ -180,22 +200,7 @@ export function ApproveMembershipForm({
                 type="button"
                 className="flex-1"
                 disabled={controlsDisabled}
-                onClick={() => {
-                  setError(null);
-                  setMessage(null);
-                  const fd = new FormData();
-                  fd.set("token", token);
-                  fd.set("planId", planId);
-                  startTransition(async () => {
-                    const result = await approveMembershipAction(fd);
-                    if (result.ok) {
-                      setStatus(MEMBERSHIP_STATUS.APPROVED);
-                      setMessage(result.message);
-                    } else {
-                      setError(result.message);
-                    }
-                  });
-                }}
+                onClick={() => openConfirm("approve")}
               >
                 {isPending ? "Working..." : "Approve & email payment options"}
               </Button>
@@ -204,21 +209,7 @@ export function ApproveMembershipForm({
                 variant="outline"
                 className="flex-1"
                 disabled={controlsDisabled}
-                onClick={() => {
-                  setError(null);
-                  setMessage(null);
-                  const fd = new FormData();
-                  fd.set("token", token);
-                  startTransition(async () => {
-                    const result = await rejectMembershipAction(fd);
-                    if (result.ok) {
-                      setStatus(MEMBERSHIP_STATUS.REJECTED);
-                      setMessage(result.message);
-                    } else {
-                      setError(result.message);
-                    }
-                  });
-                }}
+                onClick={() => openConfirm("reject")}
               >
                 Reject
               </Button>
@@ -267,6 +258,72 @@ export function ApproveMembershipForm({
           <p className="text-sm text-green-700 dark:text-green-400">{message}</p>
         )}
       </CardContent>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {confirmAction === "approve"
+                ? "Approve this application?"
+                : "Reject this application?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmAction === "approve" ? (
+                <>
+                  Approve {applicantName} for{" "}
+                  <strong>{getPlanLabel(planId)}</strong>? They will be emailed
+                  payment options.
+                </>
+              ) : (
+                <>
+                  Reject {applicantName}&apos;s application? They will be
+                  notified by email. This cannot be undone from this screen.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant={confirmAction === "reject" ? "destructive" : "default"}
+              disabled={isPending}
+              onClick={() => {
+                setError(null);
+                setMessage(null);
+                if (confirmAction === "approve") {
+                  const fd = new FormData();
+                  fd.set("token", token);
+                  fd.set("planId", planId);
+                  startTransition(async () => {
+                    const result = await approveMembershipAction(fd);
+                    if (result.ok) {
+                      setStatus(MEMBERSHIP_STATUS.APPROVED);
+                      setMessage(result.message);
+                    } else {
+                      setError(result.message);
+                    }
+                  });
+                } else {
+                  const fd = new FormData();
+                  fd.set("token", token);
+                  startTransition(async () => {
+                    const result = await rejectMembershipAction(fd);
+                    if (result.ok) {
+                      setStatus(MEMBERSHIP_STATUS.REJECTED);
+                      setMessage(result.message);
+                    } else {
+                      setError(result.message);
+                    }
+                  });
+                }
+                setConfirmOpen(false);
+              }}
+            >
+              {confirmAction === "approve" ? "Approve" : "Reject"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   );
 }

--- a/joca-app/src/app/admin/approve-membership/ApproveMembershipForm.tsx
+++ b/joca-app/src/app/admin/approve-membership/ApproveMembershipForm.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/membership-plans";
 import {
   approveMembershipAction,
+  confirmEtransferAction,
   rejectMembershipAction,
 } from "./actions";
 
@@ -49,10 +50,12 @@ export function ApproveMembershipForm({
   token,
   applicant,
   hasActiveSubscription,
+  etransferEnabled,
 }: {
   token: string;
   applicant: Applicant;
   hasActiveSubscription: boolean;
+  etransferEnabled: boolean;
 }) {
   const [planId, setPlanId] = useState(
     applicant.approvedPlan ||
@@ -60,27 +63,46 @@ export function ApproveMembershipForm({
       MEMBERSHIP_PLANS[0].id,
   );
   const [status, setStatus] = useState(applicant.membershipStatus);
-  const [message, setMessage] = useState<string | null>(
-    isDecidedStatus(applicant.membershipStatus)
-      ? "This application has already been decided. No further action is needed."
-      : null,
-  );
+  const [paid, setPaid] = useState(hasActiveSubscription);
+  const [message, setMessage] = useState<string | null>(() => {
+    if (hasActiveSubscription) {
+      return "This member already has an active membership.";
+    }
+    if (applicant.membershipStatus === MEMBERSHIP_STATUS.REJECTED) {
+      return "This application was rejected. No further action is needed.";
+    }
+    if (applicant.membershipStatus === MEMBERSHIP_STATUS.APPROVED) {
+      return etransferEnabled
+        ? "Application already approved. Confirm Interac e-Transfer below once payment is received, or the member can pay by card."
+        : "Application already approved. The member can complete card payment via the emailed Stripe link.";
+    }
+    return null;
+  });
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const decided = isDecidedStatus(status);
+  const awaitingEtransfer =
+    !paid && status === MEMBERSHIP_STATUS.APPROVED && etransferEnabled;
   const controlsDisabled = isPending || decided;
 
-  if (hasActiveSubscription) {
+  if (paid) {
     return (
       <Card className="w-full max-w-xl mx-auto my-12">
         <CardHeader>
-          <CardTitle>Already a member</CardTitle>
+          <CardTitle>Membership active</CardTitle>
           <CardDescription>
             {applicant.firstName} {applicant.lastName} already has an active
             membership. No further action is needed.
           </CardDescription>
         </CardHeader>
+        {message && (
+          <CardContent>
+            <p className="text-sm text-green-700 dark:text-green-400">
+              {message}
+            </p>
+          </CardContent>
+        )}
       </Card>
     );
   }
@@ -90,9 +112,11 @@ export function ApproveMembershipForm({
       <CardHeader>
         <CardTitle>Review membership application</CardTitle>
         <CardDescription>
-          {decided
-            ? "This application has already been reviewed."
-            : "Confirm or change the membership type, then approve to email a Stripe payment link to the member."}
+          {!decided
+            ? "Confirm or change the membership type, then approve to email payment options to the member."
+            : status === MEMBERSHIP_STATUS.APPROVED
+              ? "Waiting for payment. Confirm Interac e-Transfer when funds arrive, or wait for Stripe Checkout."
+              : "This application has already been reviewed."}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -151,10 +175,6 @@ export function ApproveMembershipForm({
               </Select>
             </div>
 
-            {error && (
-              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
-            )}
-
             <div className="flex flex-col sm:flex-row gap-3">
               <Button
                 type="button"
@@ -177,7 +197,7 @@ export function ApproveMembershipForm({
                   });
                 }}
               >
-                {isPending ? "Working..." : "Approve & email payment link"}
+                {isPending ? "Working..." : "Approve & email payment options"}
               </Button>
               <Button
                 type="button"
@@ -206,6 +226,43 @@ export function ApproveMembershipForm({
           </div>
         )}
 
+        {awaitingEtransfer && (
+          <div className="space-y-3 rounded-md border p-4">
+            <p className="text-sm text-muted-foreground">
+              After you receive the member&apos;s Interac e-Transfer in the
+              bank inbox, confirm it here to activate their membership. This
+              does not appear in Stripe.
+            </p>
+            <Button
+              type="button"
+              className="w-full"
+              disabled={isPending}
+              onClick={() => {
+                setError(null);
+                setMessage(null);
+                const fd = new FormData();
+                fd.set("token", token);
+                startTransition(async () => {
+                  const result = await confirmEtransferAction(fd);
+                  if (result.ok) {
+                    setPaid(true);
+                    setMessage(result.message);
+                  } else {
+                    setError(result.message);
+                  }
+                });
+              }}
+            >
+              {isPending
+                ? "Working..."
+                : "Mark Interac e-Transfer as received"}
+            </Button>
+          </div>
+        )}
+
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
         {message && (
           <p className="text-sm text-green-700 dark:text-green-400">{message}</p>
         )}

--- a/joca-app/src/app/admin/approve-membership/actions.ts
+++ b/joca-app/src/app/admin/approve-membership/actions.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import { verifyMembershipApprovalToken } from "@/lib/membership-approval-token";
+import {
+  approveMembershipApplication,
+  rejectMembershipApplication,
+} from "@/lib/membership-checkout";
+import { isMembershipPlanId } from "@/lib/membership-plans";
+
+export type ApproveActionResult =
+  | { ok: true; message: string }
+  | { ok: false; message: string };
+
+export async function approveMembershipAction(formData: FormData): Promise<ApproveActionResult> {
+  const token = String(formData.get("token") ?? "");
+  const planId = String(formData.get("planId") ?? "");
+
+  const verified = verifyMembershipApprovalToken(token);
+  if (!verified) {
+    return { ok: false, message: "This approval link is invalid or has expired." };
+  }
+
+  if (!isMembershipPlanId(planId)) {
+    return { ok: false, message: "Please select a valid membership plan." };
+  }
+
+  try {
+    await approveMembershipApplication({
+      userId: verified.userId,
+      planId,
+    });
+    return {
+      ok: true,
+      message:
+        "Application approved. A Stripe payment link has been emailed to the member.",
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to approve application.";
+    return { ok: false, message };
+  }
+}
+
+export async function rejectMembershipAction(formData: FormData): Promise<ApproveActionResult> {
+  const token = String(formData.get("token") ?? "");
+
+  const verified = verifyMembershipApprovalToken(token);
+  if (!verified) {
+    return { ok: false, message: "This approval link is invalid or has expired." };
+  }
+
+  try {
+    await rejectMembershipApplication({ userId: verified.userId });
+    return {
+      ok: true,
+      message: "Application rejected. The member has been notified by email.",
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to reject application.";
+    return { ok: false, message };
+  }
+}

--- a/joca-app/src/app/admin/approve-membership/actions.ts
+++ b/joca-app/src/app/admin/approve-membership/actions.ts
@@ -3,6 +3,7 @@
 import { verifyMembershipApprovalToken } from "@/lib/membership-approval-token";
 import {
   approveMembershipApplication,
+  confirmEtransferPayment,
   rejectMembershipApplication,
 } from "@/lib/membership-checkout";
 import { isMembershipPlanId } from "@/lib/membership-plans";
@@ -11,13 +12,18 @@ export type ApproveActionResult =
   | { ok: true; message: string }
   | { ok: false; message: string };
 
-export async function approveMembershipAction(formData: FormData): Promise<ApproveActionResult> {
+export async function approveMembershipAction(
+  formData: FormData,
+): Promise<ApproveActionResult> {
   const token = String(formData.get("token") ?? "");
   const planId = String(formData.get("planId") ?? "");
 
   const verified = verifyMembershipApprovalToken(token);
   if (!verified) {
-    return { ok: false, message: "This approval link is invalid or has expired." };
+    return {
+      ok: false,
+      message: "This approval link is invalid or has expired.",
+    };
   }
 
   if (!isMembershipPlanId(planId)) {
@@ -32,7 +38,7 @@ export async function approveMembershipAction(formData: FormData): Promise<Appro
     return {
       ok: true,
       message:
-        "Application approved. A Stripe payment link has been emailed to the member.",
+        "Application approved. Payment options (card and Interac e-Transfer, if configured) have been emailed to the member.",
     };
   } catch (error) {
     const message =
@@ -41,12 +47,17 @@ export async function approveMembershipAction(formData: FormData): Promise<Appro
   }
 }
 
-export async function rejectMembershipAction(formData: FormData): Promise<ApproveActionResult> {
+export async function rejectMembershipAction(
+  formData: FormData,
+): Promise<ApproveActionResult> {
   const token = String(formData.get("token") ?? "");
 
   const verified = verifyMembershipApprovalToken(token);
   if (!verified) {
-    return { ok: false, message: "This approval link is invalid or has expired." };
+    return {
+      ok: false,
+      message: "This approval link is invalid or has expired.",
+    };
   }
 
   try {
@@ -58,6 +69,35 @@ export async function rejectMembershipAction(formData: FormData): Promise<Approv
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Failed to reject application.";
+    return { ok: false, message };
+  }
+}
+
+export async function confirmEtransferAction(
+  formData: FormData,
+): Promise<ApproveActionResult> {
+  const token = String(formData.get("token") ?? "");
+
+  const verified = verifyMembershipApprovalToken(token);
+  if (!verified) {
+    return {
+      ok: false,
+      message: "This approval link is invalid or has expired.",
+    };
+  }
+
+  try {
+    await confirmEtransferPayment({ userId: verified.userId });
+    return {
+      ok: true,
+      message:
+        "Interac e-Transfer confirmed. Membership is active and the member has been notified.",
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Failed to confirm e-Transfer payment.";
     return { ok: false, message };
   }
 }

--- a/joca-app/src/app/admin/approve-membership/page.tsx
+++ b/joca-app/src/app/admin/approve-membership/page.tsx
@@ -3,6 +3,7 @@ import { verifyMembershipApprovalToken } from "@/lib/membership-approval-token";
 import prisma from "@/lib/prisma";
 import { ApproveMembershipForm } from "./ApproveMembershipForm";
 import Loading from "@/app/loading";
+import { getEtransferInstructions } from "@/lib/membership-etransfer";
 
 interface Props {
   searchParams: Promise<{ token?: string }>;
@@ -73,6 +74,7 @@ async function ApproveMembershipContent({
       token={token}
       applicant={user}
       hasActiveSubscription={Boolean(activeSubscription)}
+      etransferEnabled={Boolean(getEtransferInstructions())}
     />
   );
 }

--- a/joca-app/src/app/admin/approve-membership/page.tsx
+++ b/joca-app/src/app/admin/approve-membership/page.tsx
@@ -1,0 +1,86 @@
+import { Suspense } from "react";
+import { verifyMembershipApprovalToken } from "@/lib/membership-approval-token";
+import prisma from "@/lib/prisma";
+import { ApproveMembershipForm } from "./ApproveMembershipForm";
+import Loading from "@/app/loading";
+
+interface Props {
+  searchParams: Promise<{ token?: string }>;
+}
+
+async function ApproveMembershipContent({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>;
+}) {
+  const { token } = await searchParams;
+
+  if (!token) {
+    return (
+      <div className="container mx-auto p-8 max-w-xl text-center">
+        <h1 className="text-2xl font-semibold mb-2">Missing approval link</h1>
+        <p className="text-muted-foreground">
+          Open the review link from the JOCA membership application email.
+        </p>
+      </div>
+    );
+  }
+
+  const verified = verifyMembershipApprovalToken(token);
+  if (!verified) {
+    return (
+      <div className="container mx-auto p-8 max-w-xl text-center">
+        <h1 className="text-2xl font-semibold mb-2">Invalid or expired link</h1>
+        <p className="text-muted-foreground">
+          This approval link is invalid or has expired. Ask the member to
+          re-verify their email, or request a fresh notification from the team.
+        </p>
+      </div>
+    );
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: verified.userId },
+    select: {
+      firstName: true,
+      lastName: true,
+      email: true,
+      phoneNumber: true,
+      requestedPlan: true,
+      approvedPlan: true,
+      membershipStatus: true,
+    },
+  });
+
+  if (!user) {
+    return (
+      <div className="container mx-auto p-8 max-w-xl text-center">
+        <h1 className="text-2xl font-semibold mb-2">Applicant not found</h1>
+        <p className="text-muted-foreground">
+          This user account no longer exists.
+        </p>
+      </div>
+    );
+  }
+
+  const activeSubscription = await prisma.subscription.findFirst({
+    where: { referenceId: verified.userId, status: "active" },
+    select: { id: true },
+  });
+
+  return (
+    <ApproveMembershipForm
+      token={token}
+      applicant={user}
+      hasActiveSubscription={Boolean(activeSubscription)}
+    />
+  );
+}
+
+export default function ApproveMembershipPage({ searchParams }: Props) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <ApproveMembershipContent searchParams={searchParams} />
+    </Suspense>
+  );
+}

--- a/joca-app/src/app/api/me/membership/route.ts
+++ b/joca-app/src/app/api/me/membership/route.ts
@@ -9,13 +9,16 @@ export async function GET() {
   });
 
   if (!session?.user) {
-    return NextResponse.json({ active: false });
+    return NextResponse.json({ active: false, stripeBilling: false });
   }
 
   const activeSubscription = await prisma.subscription.findFirst({
     where: { referenceId: session.user.id, status: "active" },
-    select: { id: true },
+    select: { id: true, stripeSubscriptionId: true },
   });
 
-  return NextResponse.json({ active: Boolean(activeSubscription) });
+  const active = Boolean(activeSubscription);
+  const stripeBilling = Boolean(activeSubscription?.stripeSubscriptionId);
+
+  return NextResponse.json({ active, stripeBilling });
 }

--- a/joca-app/src/app/api/me/membership/route.ts
+++ b/joca-app/src/app/api/me/membership/route.ts
@@ -2,6 +2,14 @@ import { auth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
+import { isEmailUnverified } from "@/lib/email-verification";
+import { MEMBERSHIP_STATUS } from "@/lib/membership-plans";
+import { isJocaAdminEmail } from "@/lib/joca-admin";
+
+export type MembershipTodo =
+  | "review_application"
+  | "complete_payment"
+  | null;
 
 export async function GET() {
   const session = await auth.api.getSession({
@@ -9,16 +17,72 @@ export async function GET() {
   });
 
   if (!session?.user) {
-    return NextResponse.json({ active: false, stripeBilling: false });
+    return NextResponse.json({
+      active: false,
+      stripeBilling: false,
+      todo: null as MembershipTodo,
+      isAdmin: false,
+      pendingApplicationCount: 0,
+    });
   }
 
-  const activeSubscription = await prisma.subscription.findFirst({
-    where: { referenceId: session.user.id, status: "active" },
-    select: { id: true, stripeSubscriptionId: true },
-  });
+  const userId = session.user.id;
+  const email = session.user.email;
+
+  const [activeSubscription, dbUser] = await Promise.all([
+    prisma.subscription.findFirst({
+      where: { referenceId: userId, status: "active" },
+      select: { id: true, stripeSubscriptionId: true },
+    }),
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        emailVerified: true,
+        membershipStatus: true,
+        approvedPlan: true,
+      },
+    }),
+  ]);
 
   const active = Boolean(activeSubscription);
   const stripeBilling = Boolean(activeSubscription?.stripeSubscriptionId);
 
-  return NextResponse.json({ active, stripeBilling });
+  let todo: MembershipTodo = null;
+  if (!isEmailUnverified(dbUser ?? session.user) && !active) {
+    if (dbUser?.membershipStatus === MEMBERSHIP_STATUS.PENDING_APPROVAL) {
+      todo = "review_application";
+    } else if (
+      dbUser?.membershipStatus === MEMBERSHIP_STATUS.APPROVED &&
+      dbUser.approvedPlan
+    ) {
+      todo = "complete_payment";
+    }
+  }
+
+  const isAdmin = isJocaAdminEmail(email);
+  let pendingApplicationCount = 0;
+  if (isAdmin) {
+    // Match /admin/applications: pending review + approved but unpaid.
+    pendingApplicationCount = await prisma.user.count({
+      where: {
+        emailVerified: true,
+        OR: [
+          { membershipStatus: MEMBERSHIP_STATUS.PENDING_APPROVAL },
+          {
+            membershipStatus: MEMBERSHIP_STATUS.APPROVED,
+            NOT: { subscription: { is: { status: "active" } } },
+          },
+        ],
+      },
+    });
+  }
+
+  return NextResponse.json({
+    active,
+    stripeBilling,
+    todo,
+    isAdmin,
+    pendingApplicationCount,
+  });
 }
+

--- a/joca-app/src/app/api/me/membership/route.ts
+++ b/joca-app/src/app/api/me/membership/route.ts
@@ -1,0 +1,21 @@
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session?.user) {
+    return NextResponse.json({ active: false });
+  }
+
+  const activeSubscription = await prisma.subscription.findFirst({
+    where: { referenceId: session.user.id, status: "active" },
+    select: { id: true },
+  });
+
+  return NextResponse.json({ active: Boolean(activeSubscription) });
+}

--- a/joca-app/src/app/elections/page.tsx
+++ b/joca-app/src/app/elections/page.tsx
@@ -10,6 +10,7 @@ import { getElections, getVotedElectionIds } from "@/lib/strapi";
 import type { Election } from "@/lib/types";
 import Loading from "../loading";
 import { isEmailUnverified } from "@/lib/email-verification";
+import { MEMBERSHIP_STATUS } from "@/lib/membership-plans";
 
 async function ElectionsList({
   userId,
@@ -50,7 +51,23 @@ async function ElectionsContent() {
     where: { referenceId: session.user.id, status: "active" },
   });
 
-  if (!activeSubscription) return <NotPaid />;
+  if (!activeSubscription) {
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { membershipStatus: true },
+    });
+    if (user?.membershipStatus === MEMBERSHIP_STATUS.APPROVED) {
+      return (
+        <NotPaid
+          href="/payment"
+          title="Payment required"
+          description="Your membership was approved. Complete payment to access elections."
+          cta="Complete payment"
+        />
+      );
+    }
+    return <NotPaid />;
+  }
 
   return (
     <ElectionsList

--- a/joca-app/src/app/email-verification/EmailVerificationPage.tsx
+++ b/joca-app/src/app/email-verification/EmailVerificationPage.tsx
@@ -48,7 +48,7 @@ export const EmailVerification = ({
     setIsLoading(true);
     try {
       await sendVerificationEmail(
-        { email, callbackURL: "/payment" },
+        { email, callbackURL: "/pending" },
         {
           onSuccess: () => {
             localStorage.setItem(STORAGE_KEY, Date.now().toString());
@@ -76,7 +76,7 @@ export const EmailVerification = ({
       <div className="text-center text-muted-foreground flex flex-col items-center justify-center gap-4">
         Email verified already.
         <Button variant="outline" asChild>
-          <Link href="/payment">Go to payment page</Link>
+          <Link href="/pending">Continue</Link>
         </Button>
       </div>
     );

--- a/joca-app/src/app/email-verification/page.tsx
+++ b/joca-app/src/app/email-verification/page.tsx
@@ -15,7 +15,7 @@ async function EmailVerificationContent({
   searchParams: Promise<{ name?: string; email?: string }>;
 }) {
   const session = await auth.api.getSession({ headers: await headers() });
-  if (session?.user?.emailVerified) redirect("/payment");
+  if (session?.user?.emailVerified) redirect("/pending");
 
   const { name: nameParam, email: emailParam } = await searchParams;
 

--- a/joca-app/src/app/payment/StartPaymentPage.tsx
+++ b/joca-app/src/app/payment/StartPaymentPage.tsx
@@ -8,47 +8,36 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useSessionReady, subscription } from "@/lib/auth-client";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import Loading from "../loading";
 import { NotLoggedIn } from "@/components/NotLoggedIn";
+import { getPlanLabel } from "@/lib/membership-plans";
 
-const PLANS = [
-  { id: "senior-membership", label: "Senior Membership" },
-  { id: "general-membership", label: "General Membership" },
-  { id: "family-membership", label: "Family Membership" },
-  {
-    id: "student-associate-membership",
-    label: "Student / Associate Membership",
-  },
-];
-
-export const StartPaymentPage = () => {
+export const StartPaymentPage = ({
+  approvedPlan,
+}: {
+  approvedPlan: string;
+}) => {
   const { data: session, isPending } = useSessionReady();
   const [isLoading, setIsLoading] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
-  const [selectedPlan, setSelectedPlan] = useState<string>("");
 
   useEffect(() => setIsMounted(true), []);
 
   const handlePayment = async () => {
-    if (!selectedPlan) {
-      toast.error("Please select a membership plan.");
-      return;
-    }
     setIsLoading(true);
     try {
       const result = await subscription.upgrade({
-        plan: selectedPlan,
+        plan: approvedPlan,
         successUrl: "/payment/success",
         cancelUrl: "/payment/cancel",
       });
       if (result?.error) {
         toast.error(
-          result.error.message || "Failed to initiate payment. Please try again.",
+          result.error.message ||
+            "Failed to initiate payment. Please try again.",
         );
         return;
       }
@@ -67,32 +56,19 @@ export const StartPaymentPage = () => {
     <div className="container mx-auto p-8 max-w-2xl">
       <Card>
         <CardHeader>
-          <CardTitle>JOCA Membership Payment</CardTitle>
+          <CardTitle>Complete JOCA membership payment</CardTitle>
           <CardDescription>
-            Select a membership plan and complete your payment
+            Your application was approved for{" "}
+            <strong>{getPlanLabel(approvedPlan)}</strong>. Complete payment to
+            activate your membership.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
-          <RadioGroup value={selectedPlan} onValueChange={setSelectedPlan}>
-            {PLANS.map((plan) => (
-              <div
-                key={plan.id}
-                className="flex items-center space-x-3 rounded-md border p-4"
-              >
-                <RadioGroupItem value={plan.id} id={plan.id} />
-                <Label
-                  htmlFor={plan.id}
-                  className="cursor-pointer flex-1 leading-5"
-                >
-                  {plan.label}
-                </Label>
-              </div>
-            ))}
-          </RadioGroup>
           <div className="space-y-2">
             <p className="text-sm text-muted-foreground">
               You will be redirected to Stripe Checkout to securely complete
-              your payment.
+              your payment. You may also use the payment link emailed to you
+              after approval.
             </p>
             <p className="text-sm text-muted-foreground">
               Payment methods accepted: Credit/Debit cards.
@@ -100,7 +76,7 @@ export const StartPaymentPage = () => {
           </div>
           <Button
             onClick={handlePayment}
-            disabled={isLoading || !selectedPlan}
+            disabled={isLoading}
             className="w-full"
             size="lg"
           >

--- a/joca-app/src/app/payment/StartPaymentPage.tsx
+++ b/joca-app/src/app/payment/StartPaymentPage.tsx
@@ -17,8 +17,12 @@ import { getPlanLabel } from "@/lib/membership-plans";
 
 export const StartPaymentPage = ({
   approvedPlan,
+  etransferEmail,
+  etransferNotes,
 }: {
   approvedPlan: string;
+  etransferEmail: string | null;
+  etransferNotes: string | null;
 }) => {
   const { data: session, isPending } = useSessionReady();
   const [isLoading, setIsLoading] = useState(false);
@@ -63,25 +67,44 @@ export const StartPaymentPage = ({
             activate your membership.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="space-y-2">
+        <CardContent className="space-y-8">
+          <div className="space-y-4">
+            <h2 className="text-sm font-semibold">Pay by card</h2>
             <p className="text-sm text-muted-foreground">
               You will be redirected to Stripe Checkout to securely complete
-              your payment. You may also use the payment link emailed to you
-              after approval.
+              your payment. You may also use the card payment link emailed to
+              you after approval.
             </p>
-            <p className="text-sm text-muted-foreground">
-              Payment methods accepted: Credit/Debit cards.
-            </p>
+            <Button
+              onClick={handlePayment}
+              disabled={isLoading}
+              className="w-full"
+              size="lg"
+            >
+              {isLoading ? "Processing..." : "Pay with card"}
+            </Button>
           </div>
-          <Button
-            onClick={handlePayment}
-            disabled={isLoading}
-            className="w-full"
-            size="lg"
-          >
-            {isLoading ? "Processing..." : "Make Payment"}
-          </Button>
+
+          {etransferEmail && (
+            <div className="space-y-3 border-t pt-6">
+              <h2 className="text-sm font-semibold">
+                Pay by Interac e-Transfer
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Send an Interac e-Transfer for your{" "}
+                <strong>{getPlanLabel(approvedPlan)}</strong> to:
+              </p>
+              <p className="text-sm font-medium">{etransferEmail}</p>
+              {etransferNotes && (
+                <p className="text-sm text-muted-foreground">{etransferNotes}</p>
+              )}
+              <p className="text-sm text-muted-foreground">
+                Include your full name and account email in the message so JOCA
+                can match your payment. Access is activated after staff confirm
+                receipt — this is not automatic.
+              </p>
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/joca-app/src/app/payment/StartPaymentPage.tsx
+++ b/joca-app/src/app/payment/StartPaymentPage.tsx
@@ -14,15 +14,20 @@ import { toast } from "sonner";
 import Loading from "../loading";
 import { NotLoggedIn } from "@/components/NotLoggedIn";
 import { getPlanLabel } from "@/lib/membership-plans";
+import { formatEtransferSecurityLine } from "@/lib/etransfer-copy";
 
 export const StartPaymentPage = ({
   approvedPlan,
   etransferEmail,
   etransferNotes,
+  etransferSecurityQuestion,
+  etransferSecurityAnswer,
 }: {
   approvedPlan: string;
   etransferEmail: string | null;
   etransferNotes: string | null;
+  etransferSecurityQuestion: string | null;
+  etransferSecurityAnswer: string | null;
 }) => {
   const { data: session, isPending } = useSessionReady();
   const [isLoading, setIsLoading] = useState(false);
@@ -55,6 +60,15 @@ export const StartPaymentPage = ({
   if (!isMounted || isPending) return <Loading />;
 
   if (!session?.user) return <NotLoggedIn />;
+
+  const etransferSecurityLine = formatEtransferSecurityLine({
+    securityQuestion: etransferSecurityQuestion,
+    securityAnswer: etransferSecurityAnswer,
+    notes: etransferNotes,
+    strong: (children) => (
+      <strong className="text-foreground">{children}</strong>
+    ),
+  });
 
   return (
     <div className="container mx-auto p-8 max-w-2xl">
@@ -95,8 +109,10 @@ export const StartPaymentPage = ({
                 <strong>{getPlanLabel(approvedPlan)}</strong> to:
               </p>
               <p className="text-sm font-medium">{etransferEmail}</p>
-              {etransferNotes && (
-                <p className="text-sm text-muted-foreground">{etransferNotes}</p>
+              {etransferSecurityLine && (
+                <p className="text-sm text-muted-foreground">
+                  {etransferSecurityLine}
+                </p>
               )}
               <p className="text-sm text-muted-foreground">
                 Include your full name and account email in the message so JOCA

--- a/joca-app/src/app/payment/page.tsx
+++ b/joca-app/src/app/payment/page.tsx
@@ -7,6 +7,7 @@ import { EmailNotVerified } from "@/components/EmailNotVerified";
 import prisma from "@/lib/prisma";
 import { isEmailUnverified } from "@/lib/email-verification";
 import { MEMBERSHIP_STATUS } from "@/lib/membership-plans";
+import { getEtransferInstructions } from "@/lib/membership-etransfer";
 import Loading from "../loading";
 
 async function PaymentGate() {
@@ -37,7 +38,15 @@ async function PaymentGate() {
     redirect("/pending");
   }
 
-  return <StartPaymentPage approvedPlan={user.approvedPlan} />;
+  const etransfer = getEtransferInstructions();
+
+  return (
+    <StartPaymentPage
+      approvedPlan={user.approvedPlan}
+      etransferEmail={etransfer?.email ?? null}
+      etransferNotes={etransfer?.notes ?? null}
+    />
+  );
 }
 
 export default function PaymentPage() {

--- a/joca-app/src/app/payment/page.tsx
+++ b/joca-app/src/app/payment/page.tsx
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import { EmailNotVerified } from "@/components/EmailNotVerified";
 import prisma from "@/lib/prisma";
 import { isEmailUnverified } from "@/lib/email-verification";
+import { MEMBERSHIP_STATUS } from "@/lib/membership-plans";
 import Loading from "../loading";
 
 async function PaymentGate() {
@@ -24,7 +25,19 @@ async function PaymentGate() {
   });
   if (activeSubscription) redirect("/payment/success");
 
-  return <StartPaymentPage />;
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { membershipStatus: true, approvedPlan: true },
+  });
+
+  if (
+    user?.membershipStatus !== MEMBERSHIP_STATUS.APPROVED ||
+    !user.approvedPlan
+  ) {
+    redirect("/pending");
+  }
+
+  return <StartPaymentPage approvedPlan={user.approvedPlan} />;
 }
 
 export default function PaymentPage() {

--- a/joca-app/src/app/payment/page.tsx
+++ b/joca-app/src/app/payment/page.tsx
@@ -45,6 +45,8 @@ async function PaymentGate() {
       approvedPlan={user.approvedPlan}
       etransferEmail={etransfer?.email ?? null}
       etransferNotes={etransfer?.notes ?? null}
+      etransferSecurityQuestion={etransfer?.securityQuestion ?? null}
+      etransferSecurityAnswer={etransfer?.securityAnswer ?? null}
     />
   );
 }

--- a/joca-app/src/app/pending/page.tsx
+++ b/joca-app/src/app/pending/page.tsx
@@ -1,0 +1,99 @@
+import { Suspense } from "react";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { EmailNotVerified } from "@/components/EmailNotVerified";
+import { NotLoggedIn } from "@/components/NotLoggedIn";
+import prisma from "@/lib/prisma";
+import { isEmailUnverified } from "@/lib/email-verification";
+import { MEMBERSHIP_STATUS, getPlanLabel } from "@/lib/membership-plans";
+import Loading from "../loading";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+async function PendingContent() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session?.user) return <NotLoggedIn />;
+
+  if (isEmailUnverified(session.user)) return <EmailNotVerified />;
+
+  const activeSubscription = await prisma.subscription.findFirst({
+    where: { referenceId: session.user.id, status: "active" },
+  });
+  if (activeSubscription) redirect("/payment/success");
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: {
+      membershipStatus: true,
+      requestedPlan: true,
+      approvedPlan: true,
+    },
+  });
+
+  if (user?.membershipStatus === MEMBERSHIP_STATUS.APPROVED) {
+    redirect("/payment");
+  }
+
+  const isRejected = user?.membershipStatus === MEMBERSHIP_STATUS.REJECTED;
+
+  return (
+    <div className="container mx-auto p-8 max-w-2xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {isRejected
+              ? "Application not approved"
+              : "Application pending review"}
+          </CardTitle>
+          <CardDescription>
+            {isRejected
+              ? "JOCA was unable to approve your membership application at this time."
+              : "Thanks for verifying your email. JOCA is reviewing your application."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!isRejected && (
+            <>
+              <p className="text-sm text-muted-foreground">
+                Suggested membership:{" "}
+                <strong>{getPlanLabel(user?.requestedPlan)}</strong>
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Once approved, you will receive an email with a secure Stripe
+                payment link. After payment, you will gain access to elections
+                and membership management.
+              </p>
+            </>
+          )}
+          {isRejected && (
+            <p className="text-sm text-muted-foreground">
+              If you believe this is a mistake, please contact JOCA directly.
+            </p>
+          )}
+          <Button asChild variant="outline">
+            <Link href="/account">Go to account</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function PendingPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <PendingContent />
+    </Suspense>
+  );
+}

--- a/joca-app/src/app/signup/SignupForm.tsx
+++ b/joca-app/src/app/signup/SignupForm.tsx
@@ -21,6 +21,8 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 
 import { toast } from "sonner";
 import { signUp } from "@/lib/auth-client";
@@ -29,6 +31,15 @@ import { useRouter } from "next/navigation";
 import { useSessionReady } from "@/lib/auth-client";
 import Loading from "../loading";
 import { AlreadyLoggedIn } from "@/components/AlreadyLoggedIn";
+import {
+  MEMBERSHIP_PLANS,
+  type MembershipPlanId,
+} from "@/lib/membership-plans";
+
+const planIds = MEMBERSHIP_PLANS.map((p) => p.id) as [
+  MembershipPlanId,
+  ...MembershipPlanId[],
+];
 
 const signupSchema = z
   .object({
@@ -51,6 +62,9 @@ const signupSchema = z
       ),
     password: z.string().min(8, "Password must be at least 8 characters"),
     confirmPassword: z.string(),
+    requestedPlan: z.enum(planIds, {
+      message: "Please select a membership type",
+    }),
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: "Passwords don't match",
@@ -78,6 +92,7 @@ export const SignupForm = () => {
       phoneNumber: "",
       password: "",
       confirmPassword: "",
+      requestedPlan: undefined,
     },
   });
 
@@ -90,7 +105,8 @@ export const SignupForm = () => {
         lastName: values.lastName,
         name: values.firstName + " " + values.lastName,
         phoneNumber: values.phoneNumber,
-        callbackURL: "/payment",
+        requestedPlan: values.requestedPlan,
+        callbackURL: "/pending",
       },
       {
         onRequest: () => {
@@ -100,8 +116,8 @@ export const SignupForm = () => {
         onSuccess: () => {
           setIsLoading(false);
           if (process.env.NEXT_PUBLIC_SKIP_EMAIL_VERIFICATION === "true") {
-            toast.success("Account created!");
-            router.push("/payment");
+            toast.success("Account created! Your application is pending review.");
+            router.push("/pending");
           } else {
             // Better Auth may return synthetic success for existing emails
             // (anti-enumeration). Keep messaging honest either way.
@@ -140,14 +156,12 @@ export const SignupForm = () => {
                 onSubmit={form.handleSubmit(onSubmit)}
                 className="w-full space-y-6"
               >
-                {/* Error message */}
                 {error && (
                   <div className="p-3 text-sm text-red-500 bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-900 rounded-md">
                     {error}
                   </div>
                 )}
 
-                {/* Personal Information Section */}
                 <div className="space-y-4">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <FormField
@@ -215,6 +229,43 @@ export const SignupForm = () => {
                     )}
                   />
 
+                  <FormField
+                    control={form.control}
+                    name="requestedPlan"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Suggested membership type</FormLabel>
+                        <FormControl>
+                          <RadioGroup
+                            value={field.value}
+                            onValueChange={field.onChange}
+                            className="space-y-2"
+                          >
+                            {MEMBERSHIP_PLANS.map((plan) => (
+                              <div
+                                key={plan.id}
+                                className="flex items-center space-x-3 rounded-md border p-3"
+                              >
+                                <RadioGroupItem value={plan.id} id={plan.id} />
+                                <Label
+                                  htmlFor={plan.id}
+                                  className="cursor-pointer flex-1 leading-5"
+                                >
+                                  {plan.label}
+                                </Label>
+                              </div>
+                            ))}
+                          </RadioGroup>
+                        </FormControl>
+                        <p className="text-sm text-muted-foreground">
+                          JOCA reviews applications and confirms the final
+                          membership type before sending a payment link.
+                        </p>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <FormField
                       control={form.control}
@@ -246,7 +297,6 @@ export const SignupForm = () => {
                   </div>
                 </div>
 
-                {/* Submit button */}
                 <Button
                   type="submit"
                   className="w-full hover:cursor-pointer"

--- a/joca-app/src/components/Header.tsx
+++ b/joca-app/src/components/Header.tsx
@@ -13,18 +13,47 @@ import {
 import { useSessionReady, signOut, subscription } from "@/lib/auth-client";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { User, CreditCard, Bell, LogOut } from "lucide-react";
+import { User, CreditCard, LogOut } from "lucide-react";
 import { toast } from "sonner";
 import { Loader } from "@/components/ui/loader";
 
 const Header = () => {
   const { data: session, isPending } = useSessionReady();
   const [isMounted, setIsMounted] = useState(false);
+  const [hasActiveMembership, setHasActiveMembership] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
     setIsMounted(true);
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadMembership() {
+      if (!session?.user) {
+        if (!cancelled) setHasActiveMembership(false);
+        return;
+      }
+
+      try {
+        const res = await fetch("/api/me/membership", { credentials: "include" });
+        if (!res.ok) {
+          if (!cancelled) setHasActiveMembership(false);
+          return;
+        }
+        const data = (await res.json()) as { active?: boolean };
+        if (!cancelled) setHasActiveMembership(Boolean(data.active));
+      } catch {
+        if (!cancelled) setHasActiveMembership(false);
+      }
+    }
+
+    void loadMembership();
+    return () => {
+      cancelled = true;
+    };
+  }, [session?.user?.id]);
 
   const openBillingPortal = async () => {
     await subscription.billingPortal(
@@ -91,14 +120,17 @@ const Header = () => {
             >
               Events
             </Link>
-            {isMounted && !isPending && session?.user && (
-              <Link
-                href="/elections"
-                className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Elections
-              </Link>
-            )}
+            {isMounted &&
+              !isPending &&
+              session?.user &&
+              hasActiveMembership && (
+                <Link
+                  href="/elections"
+                  className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Elections
+                </Link>
+              )}
 
             <Link
               href="/about"
@@ -148,13 +180,15 @@ const Header = () => {
                   Account
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={openBillingPortal}
-                className="flex items-center gap-2 cursor-pointer"
-              >
-                <CreditCard className="h-4 w-4" />
-                Manage membership
-              </DropdownMenuItem>
+              {hasActiveMembership && (
+                <DropdownMenuItem
+                  onSelect={openBillingPortal}
+                  className="flex items-center gap-2 cursor-pointer"
+                >
+                  <CreditCard className="h-4 w-4" />
+                  Manage membership
+                </DropdownMenuItem>
+              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onSelect={handleLogout}

--- a/joca-app/src/components/Header.tsx
+++ b/joca-app/src/components/Header.tsx
@@ -120,17 +120,14 @@ const Header = () => {
             >
               Events
             </Link>
-            {isMounted &&
-              !isPending &&
-              session?.user &&
-              hasActiveMembership && (
-                <Link
-                  href="/elections"
-                  className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  Elections
-                </Link>
-              )}
+            {isMounted && !isPending && session?.user && (
+              <Link
+                href="/elections"
+                className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Elections
+              </Link>
+            )}
 
             <Link
               href="/about"

--- a/joca-app/src/components/Header.tsx
+++ b/joca-app/src/components/Header.tsx
@@ -13,14 +13,37 @@ import {
 import { useSessionReady, signOut, subscription } from "@/lib/auth-client";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { User, CreditCard, LogOut } from "lucide-react";
+import {
+  User,
+  CreditCard,
+  LogOut,
+  Bell,
+  ClipboardList,
+  Wallet,
+  LayoutDashboard,
+} from "lucide-react";
 import { toast } from "sonner";
 import { Loader } from "@/components/ui/loader";
+import type { MembershipTodo } from "@/app/api/me/membership/route";
+
+type MembershipState = {
+  stripeBilling: boolean;
+  todo: MembershipTodo;
+  isAdmin: boolean;
+  pendingApplicationCount: number;
+};
+
+const EMPTY_STATE: MembershipState = {
+  stripeBilling: false,
+  todo: null,
+  isAdmin: false,
+  pendingApplicationCount: 0,
+};
 
 const Header = () => {
   const { data: session, isPending } = useSessionReady();
   const [isMounted, setIsMounted] = useState(false);
-  const [hasStripeBilling, setHasStripeBilling] = useState(false);
+  const [membership, setMembership] = useState<MembershipState>(EMPTY_STATE);
   const router = useRouter();
 
   useEffect(() => {
@@ -32,25 +55,29 @@ const Header = () => {
 
     async function loadMembership() {
       if (!session?.user) {
-        if (!cancelled) setHasStripeBilling(false);
+        if (!cancelled) setMembership(EMPTY_STATE);
         return;
       }
 
       try {
-        const res = await fetch("/api/me/membership", { credentials: "include" });
+        const res = await fetch("/api/me/membership", {
+          credentials: "include",
+        });
         if (!res.ok) {
-          if (!cancelled) setHasStripeBilling(false);
+          if (!cancelled) setMembership(EMPTY_STATE);
           return;
         }
-        const data = (await res.json()) as {
-          active?: boolean;
-          stripeBilling?: boolean;
-        };
+        const data = (await res.json()) as Partial<MembershipState>;
         if (!cancelled) {
-          setHasStripeBilling(Boolean(data.stripeBilling));
+          setMembership({
+            stripeBilling: Boolean(data.stripeBilling),
+            todo: data.todo ?? null,
+            isAdmin: Boolean(data.isAdmin),
+            pendingApplicationCount: Number(data.pendingApplicationCount ?? 0),
+          });
         }
       } catch {
-        if (!cancelled) setHasStripeBilling(false);
+        if (!cancelled) setMembership(EMPTY_STATE);
       }
     }
 
@@ -95,6 +122,36 @@ const Header = () => {
       }
     }
   };
+
+  const memberTodoHref =
+    membership.todo === "review_application"
+      ? "/pending"
+      : membership.todo === "complete_payment"
+        ? "/payment"
+        : null;
+
+  const memberTodoLabel =
+    membership.todo === "review_application"
+      ? "Review Application"
+      : membership.todo === "complete_payment"
+        ? "Complete Payment"
+        : null;
+
+  const MemberTodoIcon =
+    membership.todo === "review_application"
+      ? ClipboardList
+      : membership.todo === "complete_payment"
+        ? Wallet
+        : null;
+
+  const showMemberNotification = Boolean(membership.todo);
+  const showAdminNotification =
+    membership.isAdmin && membership.pendingApplicationCount > 0;
+  const showNotificationBell = showMemberNotification || membership.isAdmin;
+
+  const notificationHref = membership.isAdmin
+    ? "/admin/applications"
+    : (memberTodoHref ?? "/");
 
   return (
     <header className="mt-2 sm:mt-0 sticky flex flex-col gap-6 sm:flex-row items-center justify-center sm:justify-between p-4 px-8 top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -158,49 +215,111 @@ const Header = () => {
           </>
         )}
         {isMounted && !isPending && session?.user && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="relative h-9 w-9 rounded-full">
-                {(session.user as { image?: string })?.image ? (
-                  <Image
-                    src={(session.user as { image: string }).image}
-                    alt=""
-                    className="h-9 w-9 rounded-full object-cover"
-                  />
-                ) : (
-                  <User className="h-5 w-5" />
-                )}
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="w-56" align="end" forceMount>
-              <DropdownMenuItem asChild>
-                <Link
-                  href="/account"
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <User className="h-4 w-4" />
-                  Account
-                </Link>
-              </DropdownMenuItem>
-              {hasStripeBilling && (
-                <DropdownMenuItem
-                  onSelect={openBillingPortal}
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  <CreditCard className="h-4 w-4" />
-                  Manage membership
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onSelect={handleLogout}
-                className="cursor-pointer"
+          <>
+            {showNotificationBell && (
+              <Button
+                variant="ghost"
+                className="relative h-9 w-9 rounded-full"
+                asChild
               >
-                <LogOut className="h-4 w-4" />
-                Sign Out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+                <Link
+                  href={notificationHref}
+                  aria-label={
+                    showAdminNotification
+                      ? `${membership.pendingApplicationCount} applications needing attention`
+                      : memberTodoLabel ?? "Notifications"
+                  }
+                >
+                  <Bell className="h-5 w-5" />
+                  {showAdminNotification ? (
+                    <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-600 px-1 text-[10px] font-semibold text-white">
+                      {membership.pendingApplicationCount > 99
+                        ? "99+"
+                        : membership.pendingApplicationCount}
+                    </span>
+                  ) : showMemberNotification ? (
+                    <span className="absolute top-1 right-1 h-2 w-2 rounded-full bg-red-600" />
+                  ) : null}
+                </Link>
+              </Button>
+            )}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="relative h-9 w-9 rounded-full"
+                >
+                  {(session.user as { image?: string })?.image ? (
+                    <Image
+                      src={(session.user as { image: string }).image}
+                      alt=""
+                      className="h-9 w-9 rounded-full object-cover"
+                    />
+                  ) : (
+                    <User className="h-5 w-5" />
+                  )}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-56" align="end" forceMount>
+                {memberTodoHref && memberTodoLabel && MemberTodoIcon && (
+                  <DropdownMenuItem asChild>
+                    <Link
+                      href={memberTodoHref}
+                      className="flex items-center gap-2 cursor-pointer"
+                    >
+                      <MemberTodoIcon className="h-4 w-4" />
+                      {memberTodoLabel}
+                    </Link>
+                  </DropdownMenuItem>
+                )}
+                {membership.isAdmin && (
+                  <DropdownMenuItem asChild>
+                    <Link
+                      href="/admin/applications"
+                      className="flex items-center gap-2 cursor-pointer"
+                    >
+                      <LayoutDashboard className="h-4 w-4" />
+                      Applications
+                      {membership.pendingApplicationCount > 0 && (
+                        <span className="ml-auto rounded-full bg-red-600 px-1.5 py-0.5 text-[10px] font-semibold text-white">
+                          {membership.pendingApplicationCount}
+                        </span>
+                      )}
+                    </Link>
+                  </DropdownMenuItem>
+                )}
+                {(memberTodoHref || membership.isAdmin) && (
+                  <DropdownMenuSeparator />
+                )}
+                <DropdownMenuItem asChild>
+                  <Link
+                    href="/account"
+                    className="flex items-center gap-2 cursor-pointer"
+                  >
+                    <User className="h-4 w-4" />
+                    Account
+                  </Link>
+                </DropdownMenuItem>
+                {membership.stripeBilling && (
+                  <DropdownMenuItem
+                    onSelect={openBillingPortal}
+                    className="flex items-center gap-2 cursor-pointer"
+                  >
+                    <CreditCard className="h-4 w-4" />
+                    Manage membership
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onSelect={handleLogout}
+                  className="cursor-pointer"
+                >
+                  <LogOut className="h-4 w-4" />
+                  Sign Out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </>
         )}
         <AnimatedThemeToggler />
       </div>

--- a/joca-app/src/components/Header.tsx
+++ b/joca-app/src/components/Header.tsx
@@ -20,7 +20,7 @@ import { Loader } from "@/components/ui/loader";
 const Header = () => {
   const { data: session, isPending } = useSessionReady();
   const [isMounted, setIsMounted] = useState(false);
-  const [hasActiveMembership, setHasActiveMembership] = useState(false);
+  const [hasStripeBilling, setHasStripeBilling] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
@@ -32,20 +32,25 @@ const Header = () => {
 
     async function loadMembership() {
       if (!session?.user) {
-        if (!cancelled) setHasActiveMembership(false);
+        if (!cancelled) setHasStripeBilling(false);
         return;
       }
 
       try {
         const res = await fetch("/api/me/membership", { credentials: "include" });
         if (!res.ok) {
-          if (!cancelled) setHasActiveMembership(false);
+          if (!cancelled) setHasStripeBilling(false);
           return;
         }
-        const data = (await res.json()) as { active?: boolean };
-        if (!cancelled) setHasActiveMembership(Boolean(data.active));
+        const data = (await res.json()) as {
+          active?: boolean;
+          stripeBilling?: boolean;
+        };
+        if (!cancelled) {
+          setHasStripeBilling(Boolean(data.stripeBilling));
+        }
       } catch {
-        if (!cancelled) setHasActiveMembership(false);
+        if (!cancelled) setHasStripeBilling(false);
       }
     }
 
@@ -177,7 +182,7 @@ const Header = () => {
                   Account
                 </Link>
               </DropdownMenuItem>
-              {hasActiveMembership && (
+              {hasStripeBilling && (
                 <DropdownMenuItem
                   onSelect={openBillingPortal}
                   className="flex items-center gap-2 cursor-pointer"

--- a/joca-app/src/components/NotPaid.tsx
+++ b/joca-app/src/components/NotPaid.tsx
@@ -1,15 +1,23 @@
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
-export const NotPaid = () => {
+export const NotPaid = ({
+  href = "/pending",
+  title = "Membership required",
+  description = "You need an active JOCA membership to access this page.",
+  cta = "Check application status",
+}: {
+  href?: string;
+  title?: string;
+  description?: string;
+  cta?: string;
+} = {}) => {
   return (
     <div className="w-full h-full flex flex-col items-center justify-center p-8 gap-4">
-      <p className="text-center text-xl">Subscription Required</p>
-      <p className="text-center text-muted-foreground">
-        You need an active subscription to access this page.
-      </p>
+      <p className="text-center text-xl">{title}</p>
+      <p className="text-center text-muted-foreground">{description}</p>
       <Button asChild>
-        <Link href="/payment">Subscribe</Link>
+        <Link href={href}>{cta}</Link>
       </Button>
     </div>
   );

--- a/joca-app/src/components/emails/MembershipActivatedTemplate.tsx
+++ b/joca-app/src/components/emails/MembershipActivatedTemplate.tsx
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Preview,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+interface MembershipActivatedTemplateProps {
+  username: string;
+  planLabel: string;
+}
+
+export const MembershipActivatedTemplate = ({
+  username,
+  planLabel,
+}: MembershipActivatedTemplateProps) => {
+  const previewText = `Your JOCA membership is now active`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Tailwind>
+        <Body className="bg-white m-auto font-sans">
+          <Container className="mb-10 mx-auto p-5 max-w-[465px]">
+            <Heading className="text-2xl text-black font-normal text-center p-0 my-8 mx-0">
+              Membership activated
+            </Heading>
+            <Text className="text-sm text-black leading-relaxed">
+              Hello {username},
+            </Text>
+            <Text className="text-sm text-black leading-relaxed">
+              We received your Interac e-Transfer. Your{" "}
+              <strong>{planLabel}</strong> membership is now active. You can
+              sign in to access elections and other member features.
+            </Text>
+            <Text className="text-sm text-black">
+              Cheers,
+              <br />
+              The JOCA Team
+            </Text>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default MembershipActivatedTemplate;

--- a/joca-app/src/components/emails/MembershipApplicationStaffTemplate.tsx
+++ b/joca-app/src/components/emails/MembershipApplicationStaffTemplate.tsx
@@ -1,0 +1,74 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+interface MembershipApplicationStaffTemplateProps {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+  requestedPlanLabel: string;
+  approveUrl: string;
+}
+
+export const MembershipApplicationStaffTemplate = ({
+  firstName,
+  lastName,
+  email,
+  phoneNumber,
+  requestedPlanLabel,
+  approveUrl,
+}: MembershipApplicationStaffTemplateProps) => {
+  const previewText = `New JOCA membership application from ${firstName} ${lastName}`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Tailwind>
+        <Body className="bg-white m-auto font-sans">
+          <Container className="mb-10 mx-auto p-5 max-w-[465px]">
+            <Heading className="text-2xl text-black font-normal text-center p-0 my-8 mx-0">
+              New membership application
+            </Heading>
+            <Text className="text-sm text-black leading-relaxed">
+              A new member has verified their email and is awaiting approval.
+            </Text>
+            <Text className="text-sm text-black leading-relaxed">
+              <strong>Name:</strong> {firstName} {lastName}
+              <br />
+              <strong>Email:</strong> {email}
+              <br />
+              <strong>Phone:</strong> {phoneNumber}
+              <br />
+              <strong>Requested plan:</strong> {requestedPlanLabel}
+            </Text>
+            <Text className="text-sm text-black leading-relaxed">
+              Open the link below to approve or reject. You can change the
+              membership type before approving.
+            </Text>
+            <Section className="text-center mt-[32px] mb-[32px]">
+              <Button
+                className="py-2.5 px-5 bg-black rounded-md text-white text-sm font-semibold no-underline text-center"
+                href={approveUrl}
+              >
+                Review application
+              </Button>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default MembershipApplicationStaffTemplate;

--- a/joca-app/src/components/emails/MembershipApprovedTemplate.tsx
+++ b/joca-app/src/components/emails/MembershipApprovedTemplate.tsx
@@ -15,12 +15,16 @@ interface MembershipApprovedTemplateProps {
   username: string;
   planLabel: string;
   checkoutUrl: string;
+  etransferEmail?: string | null;
+  etransferNotes?: string | null;
 }
 
 export const MembershipApprovedTemplate = ({
   username,
   planLabel,
   checkoutUrl,
+  etransferEmail,
+  etransferNotes,
 }: MembershipApprovedTemplateProps) => {
   const previewText = `Your JOCA membership application was approved`;
 
@@ -39,15 +43,19 @@ export const MembershipApprovedTemplate = ({
             </Text>
             <Text className="text-sm text-black leading-relaxed">
               Your JOCA membership application has been approved for{" "}
-              <strong>{planLabel}</strong>. Complete payment using the button
-              below to activate your membership.
+              <strong>{planLabel}</strong>. Complete payment using one of the
+              options below to activate your membership.
             </Text>
-            <Section className="text-center mt-[32px] mb-[32px]">
+
+            <Text className="text-sm text-black font-semibold leading-relaxed">
+              Option 1 — Pay by card (Stripe)
+            </Text>
+            <Section className="text-center mt-[16px] mb-[24px]">
               <Button
                 className="py-2.5 px-5 bg-black rounded-md text-white text-sm font-semibold no-underline text-center"
                 href={checkoutUrl}
               >
-                Complete payment
+                Complete card payment
               </Button>
             </Section>
             <Text className="text-sm text-black leading-relaxed">
@@ -56,6 +64,31 @@ export const MembershipApprovedTemplate = ({
               <br />
               {checkoutUrl}
             </Text>
+
+            {etransferEmail && (
+              <>
+                <Text className="text-sm text-black font-semibold leading-relaxed mt-6">
+                  Option 2 — Interac e-Transfer
+                </Text>
+                <Text className="text-sm text-black leading-relaxed">
+                  Send an Interac e-Transfer for your{" "}
+                  <strong>{planLabel}</strong> to:
+                  <br />
+                  <strong>{etransferEmail}</strong>
+                </Text>
+                {etransferNotes && (
+                  <Text className="text-sm text-black leading-relaxed">
+                    {etransferNotes}
+                  </Text>
+                )}
+                <Text className="text-sm text-black leading-relaxed">
+                  Include your full name and this email address in the message
+                  so we can match your payment. Access is activated after JOCA
+                  confirms receipt (this is not automatic).
+                </Text>
+              </>
+            )}
+
             <Text className="text-sm text-black">
               Cheers,
               <br />

--- a/joca-app/src/components/emails/MembershipApprovedTemplate.tsx
+++ b/joca-app/src/components/emails/MembershipApprovedTemplate.tsx
@@ -10,6 +10,7 @@ import {
   Tailwind,
   Text,
 } from "@react-email/components";
+import { formatEtransferSecurityLine } from "@/lib/etransfer-copy";
 
 interface MembershipApprovedTemplateProps {
   username: string;
@@ -17,6 +18,8 @@ interface MembershipApprovedTemplateProps {
   checkoutUrl: string;
   etransferEmail?: string | null;
   etransferNotes?: string | null;
+  etransferSecurityQuestion?: string | null;
+  etransferSecurityAnswer?: string | null;
 }
 
 export const MembershipApprovedTemplate = ({
@@ -25,8 +28,16 @@ export const MembershipApprovedTemplate = ({
   checkoutUrl,
   etransferEmail,
   etransferNotes,
+  etransferSecurityQuestion,
+  etransferSecurityAnswer,
 }: MembershipApprovedTemplateProps) => {
   const previewText = `Your JOCA membership application was approved`;
+  const etransferSecurityLine = formatEtransferSecurityLine({
+    securityQuestion: etransferSecurityQuestion,
+    securityAnswer: etransferSecurityAnswer,
+    notes: etransferNotes,
+    strong: (children) => <strong>{children}</strong>,
+  });
 
   return (
     <Html>
@@ -76,9 +87,9 @@ export const MembershipApprovedTemplate = ({
                   <br />
                   <strong>{etransferEmail}</strong>
                 </Text>
-                {etransferNotes && (
+                {etransferSecurityLine && (
                   <Text className="text-sm text-black leading-relaxed">
-                    {etransferNotes}
+                    {etransferSecurityLine}
                   </Text>
                 )}
                 <Text className="text-sm text-black leading-relaxed">

--- a/joca-app/src/components/emails/MembershipApprovedTemplate.tsx
+++ b/joca-app/src/components/emails/MembershipApprovedTemplate.tsx
@@ -1,0 +1,71 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+interface MembershipApprovedTemplateProps {
+  username: string;
+  planLabel: string;
+  checkoutUrl: string;
+}
+
+export const MembershipApprovedTemplate = ({
+  username,
+  planLabel,
+  checkoutUrl,
+}: MembershipApprovedTemplateProps) => {
+  const previewText = `Your JOCA membership application was approved`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Tailwind>
+        <Body className="bg-white m-auto font-sans">
+          <Container className="mb-10 mx-auto p-5 max-w-[465px]">
+            <Heading className="text-2xl text-black font-normal text-center p-0 my-8 mx-0">
+              Membership approved
+            </Heading>
+            <Text className="text-sm text-black leading-relaxed">
+              Hello {username},
+            </Text>
+            <Text className="text-sm text-black leading-relaxed">
+              Your JOCA membership application has been approved for{" "}
+              <strong>{planLabel}</strong>. Complete payment using the button
+              below to activate your membership.
+            </Text>
+            <Section className="text-center mt-[32px] mb-[32px]">
+              <Button
+                className="py-2.5 px-5 bg-black rounded-md text-white text-sm font-semibold no-underline text-center"
+                href={checkoutUrl}
+              >
+                Complete payment
+              </Button>
+            </Section>
+            <Text className="text-sm text-black leading-relaxed">
+              If the button does not work, copy and paste this link into your
+              browser:
+              <br />
+              {checkoutUrl}
+            </Text>
+            <Text className="text-sm text-black">
+              Cheers,
+              <br />
+              The JOCA Team
+            </Text>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default MembershipApprovedTemplate;

--- a/joca-app/src/components/emails/MembershipRejectedTemplate.tsx
+++ b/joca-app/src/components/emails/MembershipRejectedTemplate.tsx
@@ -1,0 +1,51 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Preview,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+interface MembershipRejectedTemplateProps {
+  username: string;
+}
+
+export const MembershipRejectedTemplate = ({
+  username,
+}: MembershipRejectedTemplateProps) => {
+  const previewText = `Update on your JOCA membership application`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Tailwind>
+        <Body className="bg-white m-auto font-sans">
+          <Container className="mb-10 mx-auto p-5 max-w-[465px]">
+            <Heading className="text-2xl text-black font-normal text-center p-0 my-8 mx-0">
+              Membership application update
+            </Heading>
+            <Text className="text-sm text-black leading-relaxed">
+              Hello {username},
+            </Text>
+            <Text className="text-sm text-black leading-relaxed">
+              Thank you for your interest in JOCA. After review, we are unable
+              to approve your membership application at this time. If you
+              believe this is a mistake, please contact JOCA directly.
+            </Text>
+            <Text className="text-sm text-black">
+              Cheers,
+              <br />
+              The JOCA Team
+            </Text>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default MembershipRejectedTemplate;

--- a/joca-app/src/components/ui/alert-dialog.tsx
+++ b/joca-app/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-16 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/joca-app/src/components/ui/button.tsx
+++ b/joca-app/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/joca-app/src/components/ui/select.tsx
+++ b/joca-app/src/components/ui/select.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/joca-app/src/lib/auth.ts
+++ b/joca-app/src/lib/auth.ts
@@ -2,12 +2,15 @@ import { betterAuth } from "better-auth";
 import { stripe } from "@better-auth/stripe";
 import Stripe from "stripe";
 import { prismaAdapter } from "better-auth/adapters/prisma";
-import { Resend } from "resend";
 import { EmailVerificationTemplate } from "@/components/EmailVerificationTemplate";
 import prisma from "@/lib/prisma";
 import { deleteMemberByEmail } from "@/lib/strapi";
 import { createAuthMiddleware } from "better-auth/api";
 import { SESSION_FRESH_AGE_SECONDS } from "@/lib/auth-constants";
+import { EMAIL_FROM, resend } from "@/lib/resend";
+import { notifyJocaOfMembershipApplication } from "@/lib/membership-notify";
+import { MEMBERSHIP_STATUS } from "@/lib/membership-plans";
+import { isEmailVerificationSkipped } from "@/lib/email-verification";
 
 const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!);
 
@@ -16,13 +19,6 @@ const isDev = process.env.NODE_ENV === "development";
 if (!isDev && !process.env.STRIPE_WEBHOOK_SECRET) {
   throw new Error("STRIPE_WEBHOOK_SECRET environment variable is not set.");
 }
-
-const resendApiKey = process.env.RESEND_API_KEY;
-if (!isDev && !resendApiKey) {
-  throw new Error("RESEND_API_KEY environment variable is not set.");
-}
-
-const resend = isDev ? null : new Resend(resendApiKey!);
 
 export const auth = betterAuth({
   baseURL: process.env.BETTER_AUTH_URL || "http://localhost:3000",
@@ -43,6 +39,20 @@ export const auth = betterAuth({
       lastName: {
         type: "string",
         required: true,
+      },
+      requestedPlan: {
+        type: "string",
+        required: true,
+      },
+      approvedPlan: {
+        type: "string",
+        required: false,
+      },
+      membershipStatus: {
+        type: "string",
+        required: false,
+        defaultValue: MEMBERSHIP_STATUS.PENDING_APPROVAL,
+        input: false,
       },
     },
     deleteUser: {
@@ -94,6 +104,18 @@ export const auth = betterAuth({
         } catch (error) {
           console.error("Failed to delete Strapi member:", error);
         }
+      },
+    },
+  },
+  databaseHooks: {
+    user: {
+      create: {
+        after: async (user) => {
+          // When verification is skipped, notify JOCA immediately (afterEmailVerification will not run).
+          if (isEmailVerificationSkipped()) {
+            await notifyJocaOfMembershipApplication(user.id);
+          }
+        },
       },
     },
   },
@@ -160,7 +182,7 @@ export const auth = betterAuth({
       }
       try {
         await resend.emails.send({
-          from: "onboarding@resend.dev", //TODO: Change to JOCA email once prod domain is verified
+          from: EMAIL_FROM, //TODO: Change to JOCA email once prod domain is verified
           to: user.email,
           subject: "Verify your email",
           react: EmailVerificationTemplate({
@@ -176,6 +198,9 @@ export const auth = betterAuth({
     sendOnSignIn: process.env.NEXT_PUBLIC_SKIP_EMAIL_VERIFICATION !== "true",
     autoSignInAfterVerification: true,
     expiresIn: 3600, //1 hour
+    afterEmailVerification: async (user: { id: string }) => {
+      await notifyJocaOfMembershipApplication(user.id);
+    },
   },
   /* Rate Limiting:
   User cannot make more than 100 requests per minute to the API

--- a/joca-app/src/lib/etransfer-copy.tsx
+++ b/joca-app/src/lib/etransfer-copy.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+/** Shared Interac security-question line with bold question/answer values. */
+export function formatEtransferSecurityLine(params: {
+  securityQuestion: string | null | undefined;
+  securityAnswer: string | null | undefined;
+  notes?: string | null;
+  strong: (children: ReactNode) => ReactNode;
+}): ReactNode | null {
+  const { securityQuestion, securityAnswer, notes, strong } = params;
+
+  if (securityQuestion && securityAnswer) {
+    return (
+      <>
+        Use security question: {strong(securityQuestion)} / answer:{" "}
+        {strong(securityAnswer)}
+        {notes ? <> / {notes}</> : null}
+      </>
+    );
+  }
+
+  if (notes) return notes;
+  return null;
+}

--- a/joca-app/src/lib/joca-admin.ts
+++ b/joca-app/src/lib/joca-admin.ts
@@ -1,0 +1,21 @@
+/**
+ * Staff who can access /admin/applications and see the actionable-application counter.
+ * Prefer JOCA_ADMIN_EMAILS (comma-separated). Falls back to JOCA_APPROVALS_EMAIL.
+ */
+export function getJocaAdminEmails(): string[] {
+  const fromList = process.env.JOCA_ADMIN_EMAILS?.split(",") ?? [];
+  const fromApprovals = process.env.JOCA_APPROVALS_EMAIL
+    ? [process.env.JOCA_APPROVALS_EMAIL]
+    : [];
+
+  return [...fromList, ...fromApprovals]
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isJocaAdminEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  const admins = getJocaAdminEmails();
+  if (admins.length === 0) return false;
+  return admins.includes(email.trim().toLowerCase());
+}

--- a/joca-app/src/lib/membership-approval-token.ts
+++ b/joca-app/src/lib/membership-approval-token.ts
@@ -1,7 +1,7 @@
 import { createHmac, timingSafeEqual } from "crypto";
 
 const PURPOSE = "membership-approve";
-const TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days (covers delayed e-Transfer confirmation)
 
 function getSecret(): string {
   const secret = process.env.BETTER_AUTH_SECRET;

--- a/joca-app/src/lib/membership-approval-token.ts
+++ b/joca-app/src/lib/membership-approval-token.ts
@@ -1,0 +1,64 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+const PURPOSE = "membership-approve";
+const TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+function getSecret(): string {
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) {
+    throw new Error("BETTER_AUTH_SECRET is not set");
+  }
+  return secret;
+}
+
+function signPayload(payload: string): string {
+  return createHmac("sha256", getSecret()).update(payload).digest("base64url");
+}
+
+export function createMembershipApprovalToken(userId: string): string {
+  const exp = Date.now() + TOKEN_TTL_MS;
+  const payload = `${PURPOSE}:${userId}:${exp}`;
+  const sig = signPayload(payload);
+  return Buffer.from(`${payload}:${sig}`).toString("base64url");
+}
+
+export function verifyMembershipApprovalToken(
+  token: string,
+): { userId: string } | null {
+  try {
+    const decoded = Buffer.from(token, "base64url").toString("utf8");
+    const parts = decoded.split(":");
+    if (parts.length !== 4) return null;
+
+    const [purpose, userId, expStr, sig] = parts;
+    if (purpose !== PURPOSE || !userId || !expStr || !sig) return null;
+
+    const exp = Number(expStr);
+    if (!Number.isFinite(exp) || Date.now() > exp) return null;
+
+    const payload = `${purpose}:${userId}:${expStr}`;
+    const expected = signPayload(payload);
+
+    const sigBuf = Buffer.from(sig);
+    const expectedBuf = Buffer.from(expected);
+    if (
+      sigBuf.length !== expectedBuf.length ||
+      !timingSafeEqual(sigBuf, expectedBuf)
+    ) {
+      return null;
+    }
+
+    return { userId };
+  } catch {
+    return null;
+  }
+}
+
+export function getApproveMembershipUrl(userId: string): string {
+  const base =
+    process.env.BETTER_AUTH_URL ||
+    process.env.NEXT_PUBLIC_BETTER_AUTH_URL ||
+    "http://localhost:3000";
+  const token = createMembershipApprovalToken(userId);
+  return `${base.replace(/\/$/, "")}/admin/approve-membership?token=${encodeURIComponent(token)}`;
+}

--- a/joca-app/src/lib/membership-checkout.ts
+++ b/joca-app/src/lib/membership-checkout.ts
@@ -218,6 +218,8 @@ export async function approveMembershipApplication(params: {
         checkoutUrl,
         etransferEmail: etransfer?.email,
         etransferNotes: etransfer?.notes,
+        etransferSecurityQuestion: etransfer?.securityQuestion,
+        etransferSecurityAnswer: etransfer?.securityAnswer,
       }),
     });
   } else {

--- a/joca-app/src/lib/membership-checkout.ts
+++ b/joca-app/src/lib/membership-checkout.ts
@@ -146,6 +146,15 @@ export async function approveMembershipApplication(params: {
   const user = await prisma.user.findUnique({ where: { id: params.userId } });
   if (!user) throw new Error("User not found");
 
+  if (
+    user.membershipStatus === MEMBERSHIP_STATUS.APPROVED ||
+    user.membershipStatus === MEMBERSHIP_STATUS.REJECTED
+  ) {
+    throw new Error(
+      "This application has already been decided and cannot be changed.",
+    );
+  }
+
   const active = await prisma.subscription.findFirst({
     where: { referenceId: user.id, status: "active" },
   });
@@ -191,6 +200,15 @@ export async function rejectMembershipApplication(params: {
 }): Promise<void> {
   const user = await prisma.user.findUnique({ where: { id: params.userId } });
   if (!user) throw new Error("User not found");
+
+  if (
+    user.membershipStatus === MEMBERSHIP_STATUS.APPROVED ||
+    user.membershipStatus === MEMBERSHIP_STATUS.REJECTED
+  ) {
+    throw new Error(
+      "This application has already been decided and cannot be changed.",
+    );
+  }
 
   const active = await prisma.subscription.findFirst({
     where: { referenceId: user.id, status: "active" },

--- a/joca-app/src/lib/membership-checkout.ts
+++ b/joca-app/src/lib/membership-checkout.ts
@@ -5,11 +5,17 @@ import {
   getPlanLabel,
   isMembershipPlanId,
   type MembershipPlanId,
+  MEMBERSHIP_STATUS,
 } from "@/lib/membership-plans";
 import { EMAIL_FROM, resend } from "@/lib/resend";
 import { MembershipApprovedTemplate } from "@/components/emails/MembershipApprovedTemplate";
 import { MembershipRejectedTemplate } from "@/components/emails/MembershipRejectedTemplate";
-import { MEMBERSHIP_STATUS } from "@/lib/membership-plans";
+import { MembershipActivatedTemplate } from "@/components/emails/MembershipActivatedTemplate";
+import { getEtransferInstructions } from "@/lib/membership-etransfer";
+import { createMember, getMemberByEmail } from "@/lib/strapi";
+
+/** Marker on Subscription.billingInterval for manual Interac e-Transfer memberships. */
+export const ETRANSFER_BILLING_INTERVAL = "etransfer";
 
 const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!);
 
@@ -59,6 +65,29 @@ async function resolvePriceId(planId: MembershipPlanId): Promise<string> {
   return price.id;
 }
 
+async function syncStrapiMember(user: {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+}): Promise<void> {
+  try {
+    const existing = await getMemberByEmail(user.email);
+    if (existing) return;
+    await createMember(
+      user.firstName,
+      user.lastName,
+      user.email,
+      user.phoneNumber,
+    );
+  } catch (error) {
+    console.error(
+      `[membership] Failed to sync Strapi Member for ${user.email}:`,
+      error,
+    );
+  }
+}
+
 /**
  * Creates (or reuses) an incomplete Subscription row and a Stripe Checkout
  * Session using the same metadata contract as @better-auth/stripe so webhooks
@@ -93,6 +122,7 @@ export async function createMembershipCheckoutUrl(params: {
         stripeCustomerId: customerId,
         status: "incomplete",
         stripeSubscriptionId: null,
+        billingInterval: null,
         updatedAt: new Date(),
       },
     });
@@ -175,6 +205,8 @@ export async function approveMembershipApplication(params: {
     planId: params.planId,
   });
 
+  const etransfer = getEtransferInstructions();
+
   if (resend) {
     await resend.emails.send({
       from: EMAIL_FROM,
@@ -184,6 +216,8 @@ export async function approveMembershipApplication(params: {
         username: user.firstName || user.name,
         planLabel: getPlanLabel(params.planId),
         checkoutUrl,
+        etransferEmail: etransfer?.email,
+        etransferNotes: etransfer?.notes,
       }),
     });
   } else {
@@ -232,6 +266,80 @@ export async function rejectMembershipApplication(params: {
       subject: "Update on your JOCA membership application",
       react: MembershipRejectedTemplate({
         username: user.firstName || user.name,
+      }),
+    });
+  }
+}
+
+/**
+ * Staff confirms an Interac e-Transfer was received and activates membership
+ * without a Stripe subscription (not visible in Stripe Dashboard).
+ */
+export async function confirmEtransferPayment(params: {
+  userId: string;
+}): Promise<void> {
+  const user = await prisma.user.findUnique({ where: { id: params.userId } });
+  if (!user) throw new Error("User not found");
+
+  if (user.membershipStatus !== MEMBERSHIP_STATUS.APPROVED) {
+    throw new Error(
+      "Application must be approved before confirming an e-Transfer payment.",
+    );
+  }
+
+  if (!user.approvedPlan || !isMembershipPlanId(user.approvedPlan)) {
+    throw new Error("Approved plan is missing; cannot activate membership.");
+  }
+
+  const existing = await prisma.subscription.findUnique({
+    where: { referenceId: user.id },
+  });
+
+  if (existing?.status === "active") {
+    throw new Error("User already has an active membership");
+  }
+
+  const now = new Date();
+  if (existing) {
+    await prisma.subscription.update({
+      where: { id: existing.id },
+      data: {
+        plan: user.approvedPlan,
+        status: "active",
+        stripeSubscriptionId: null,
+        billingInterval: ETRANSFER_BILLING_INTERVAL,
+        periodStart: now,
+        periodEnd: null,
+        cancelAtPeriodEnd: false,
+        cancelAt: null,
+        canceledAt: null,
+        endedAt: null,
+        updatedAt: now,
+      },
+    });
+  } else {
+    await prisma.subscription.create({
+      data: {
+        id: randomUUID(),
+        plan: user.approvedPlan,
+        referenceId: user.id,
+        status: "active",
+        billingInterval: ETRANSFER_BILLING_INTERVAL,
+        periodStart: now,
+      },
+    });
+  }
+
+  await syncStrapiMember(user);
+
+  if (resend) {
+    await resend.emails.send({
+      from: EMAIL_FROM,
+      to: user.email,
+      subject: "Your JOCA membership is now active",
+      react: MembershipActivatedTemplate({
+        username: user.firstName || user.name,
+        planLabel: getPlanLabel(user.approvedPlan),
       }),
     });
   }

--- a/joca-app/src/lib/membership-checkout.ts
+++ b/joca-app/src/lib/membership-checkout.ts
@@ -1,0 +1,220 @@
+import Stripe from "stripe";
+import { randomUUID } from "crypto";
+import prisma from "@/lib/prisma";
+import {
+  getPlanLabel,
+  isMembershipPlanId,
+  type MembershipPlanId,
+} from "@/lib/membership-plans";
+import { EMAIL_FROM, resend } from "@/lib/resend";
+import { MembershipApprovedTemplate } from "@/components/emails/MembershipApprovedTemplate";
+import { MembershipRejectedTemplate } from "@/components/emails/MembershipRejectedTemplate";
+import { MEMBERSHIP_STATUS } from "@/lib/membership-plans";
+
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!);
+
+function appBaseUrl(): string {
+  return (
+    process.env.BETTER_AUTH_URL ||
+    process.env.NEXT_PUBLIC_BETTER_AUTH_URL ||
+    "http://localhost:3000"
+  ).replace(/\/$/, "");
+}
+
+async function ensureStripeCustomer(user: {
+  id: string;
+  email: string;
+  name: string;
+  stripeCustomerId: string | null;
+}): Promise<string> {
+  if (user.stripeCustomerId) return user.stripeCustomerId;
+
+  const customer = await stripeClient.customers.create({
+    email: user.email,
+    name: user.name,
+    metadata: {
+      userId: user.id,
+      customerType: "user",
+    },
+  });
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { stripeCustomerId: customer.id },
+  });
+
+  return customer.id;
+}
+
+async function resolvePriceId(planId: MembershipPlanId): Promise<string> {
+  const prices = await stripeClient.prices.list({
+    lookup_keys: [planId],
+    active: true,
+    limit: 1,
+  });
+  const price = prices.data[0];
+  if (!price) {
+    throw new Error(`No active Stripe price found for lookup key: ${planId}`);
+  }
+  return price.id;
+}
+
+/**
+ * Creates (or reuses) an incomplete Subscription row and a Stripe Checkout
+ * Session using the same metadata contract as @better-auth/stripe so webhooks
+ * activate membership correctly.
+ */
+export async function createMembershipCheckoutUrl(params: {
+  userId: string;
+  planId: MembershipPlanId;
+}): Promise<string> {
+  const user = await prisma.user.findUnique({
+    where: { id: params.userId },
+  });
+  if (!user) throw new Error("User not found");
+
+  const customerId = await ensureStripeCustomer(user);
+  const priceId = await resolvePriceId(params.planId);
+
+  const existing = await prisma.subscription.findUnique({
+    where: { referenceId: user.id },
+  });
+
+  if (existing?.status === "active") {
+    throw new Error("User already has an active subscription");
+  }
+
+  let subscriptionId: string;
+  if (existing) {
+    await prisma.subscription.update({
+      where: { id: existing.id },
+      data: {
+        plan: params.planId,
+        stripeCustomerId: customerId,
+        status: "incomplete",
+        stripeSubscriptionId: null,
+        updatedAt: new Date(),
+      },
+    });
+    subscriptionId = existing.id;
+  } else {
+    subscriptionId = randomUUID();
+    await prisma.subscription.create({
+      data: {
+        id: subscriptionId,
+        plan: params.planId,
+        referenceId: user.id,
+        stripeCustomerId: customerId,
+        status: "incomplete",
+      },
+    });
+  }
+
+  const base = appBaseUrl();
+  const metadata = {
+    userId: user.id,
+    subscriptionId,
+    referenceId: user.id,
+  };
+
+  const session = await stripeClient.checkout.sessions.create({
+    mode: "subscription",
+    customer: customerId,
+    client_reference_id: user.id,
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: `${base}/payment/success`,
+    cancel_url: `${base}/payment/cancel`,
+    metadata,
+    subscription_data: { metadata },
+  });
+
+  if (!session.url) {
+    throw new Error("Stripe Checkout Session did not return a URL");
+  }
+
+  return session.url;
+}
+
+export async function approveMembershipApplication(params: {
+  userId: string;
+  planId: string;
+}): Promise<{ checkoutUrl: string }> {
+  if (!isMembershipPlanId(params.planId)) {
+    throw new Error("Invalid membership plan");
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: params.userId } });
+  if (!user) throw new Error("User not found");
+
+  const active = await prisma.subscription.findFirst({
+    where: { referenceId: user.id, status: "active" },
+  });
+  if (active) {
+    throw new Error("User already has an active membership");
+  }
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      approvedPlan: params.planId,
+      membershipStatus: MEMBERSHIP_STATUS.APPROVED,
+    },
+  });
+
+  const checkoutUrl = await createMembershipCheckoutUrl({
+    userId: user.id,
+    planId: params.planId,
+  });
+
+  if (resend) {
+    await resend.emails.send({
+      from: EMAIL_FROM,
+      to: user.email,
+      subject: "Your JOCA membership was approved — complete payment",
+      react: MembershipApprovedTemplate({
+        username: user.firstName || user.name,
+        planLabel: getPlanLabel(params.planId),
+        checkoutUrl,
+      }),
+    });
+  } else {
+    console.warn(
+      `[membership] Resend not configured; checkout URL for ${user.email}: ${checkoutUrl}`,
+    );
+  }
+
+  return { checkoutUrl };
+}
+
+export async function rejectMembershipApplication(params: {
+  userId: string;
+}): Promise<void> {
+  const user = await prisma.user.findUnique({ where: { id: params.userId } });
+  if (!user) throw new Error("User not found");
+
+  const active = await prisma.subscription.findFirst({
+    where: { referenceId: user.id, status: "active" },
+  });
+  if (active) {
+    throw new Error("Cannot reject a user with an active membership");
+  }
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      membershipStatus: MEMBERSHIP_STATUS.REJECTED,
+      approvedPlan: null,
+    },
+  });
+
+  if (resend) {
+    await resend.emails.send({
+      from: EMAIL_FROM,
+      to: user.email,
+      subject: "Update on your JOCA membership application",
+      react: MembershipRejectedTemplate({
+        username: user.firstName || user.name,
+      }),
+    });
+  }
+}

--- a/joca-app/src/lib/membership-etransfer.ts
+++ b/joca-app/src/lib/membership-etransfer.ts
@@ -1,6 +1,8 @@
 export type EtransferInstructions = {
   email: string;
   notes: string | null;
+  securityQuestion: string | null;
+  securityAnswer: string | null;
 };
 
 /**
@@ -12,5 +14,10 @@ export function getEtransferInstructions(): EtransferInstructions | null {
   if (!email) return null;
 
   const notes = process.env.JOCA_ETRANSFER_INSTRUCTIONS?.trim() || null;
-  return { email, notes };
+  const securityQuestion =
+    process.env.JOCA_ETRANSFER_SECURITY_QUESTION?.trim() || null;
+  const securityAnswer =
+    process.env.JOCA_ETRANSFER_SECURITY_ANSWER?.trim() || null;
+
+  return { email, notes, securityQuestion, securityAnswer };
 }

--- a/joca-app/src/lib/membership-etransfer.ts
+++ b/joca-app/src/lib/membership-etransfer.ts
@@ -1,0 +1,16 @@
+export type EtransferInstructions = {
+  email: string;
+  notes: string | null;
+};
+
+/**
+ * Interac e-Transfer destination for membership payments.
+ * When unset, e-Transfer copy is omitted from member-facing UI/emails.
+ */
+export function getEtransferInstructions(): EtransferInstructions | null {
+  const email = process.env.JOCA_ETRANSFER_EMAIL?.trim();
+  if (!email) return null;
+
+  const notes = process.env.JOCA_ETRANSFER_INSTRUCTIONS?.trim() || null;
+  return { email, notes };
+}

--- a/joca-app/src/lib/membership-notify.ts
+++ b/joca-app/src/lib/membership-notify.ts
@@ -1,0 +1,65 @@
+import prisma from "@/lib/prisma";
+import { EMAIL_FROM, resend } from "@/lib/resend";
+import { getApproveMembershipUrl } from "@/lib/membership-approval-token";
+import { getPlanLabel } from "@/lib/membership-plans";
+import { MembershipApplicationStaffTemplate } from "@/components/emails/MembershipApplicationStaffTemplate";
+
+/**
+ * Notify JOCA staff that a verified (or skip-verification) signup needs approval.
+ * Safe to call more than once; staff email is sent each time verification completes.
+ */
+export async function notifyJocaOfMembershipApplication(
+  userId: string,
+): Promise<void> {
+  const approvalsEmail = process.env.JOCA_APPROVALS_EMAIL;
+  if (!approvalsEmail) {
+    console.warn(
+      "[membership] JOCA_APPROVALS_EMAIL is not set; skipping staff notification.",
+    );
+    return;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+      phoneNumber: true,
+      requestedPlan: true,
+    },
+  });
+
+  if (!user) return;
+
+  const approveUrl = getApproveMembershipUrl(user.id);
+
+  if (!resend) {
+    console.warn(
+      `[membership] Resend not configured; approve URL for ${user.email}: ${approveUrl}`,
+    );
+    return;
+  }
+
+  try {
+    await resend.emails.send({
+      from: EMAIL_FROM,
+      to: approvalsEmail,
+      subject: `New JOCA membership application: ${user.firstName} ${user.lastName}`,
+      react: MembershipApplicationStaffTemplate({
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+        phoneNumber: user.phoneNumber,
+        requestedPlanLabel: getPlanLabel(user.requestedPlan),
+        approveUrl,
+      }),
+    });
+  } catch (error) {
+    console.error(
+      `[membership] Failed to notify JOCA of application for user ${userId}:`,
+      error,
+    );
+  }
+}

--- a/joca-app/src/lib/membership-plans.ts
+++ b/joca-app/src/lib/membership-plans.ts
@@ -29,3 +29,18 @@ export function getPlanLabel(planId: string | null | undefined): string {
   if (!planId) return "Unknown plan";
   return MEMBERSHIP_PLANS.find((p) => p.id === planId)?.label ?? planId;
 }
+
+const MEMBERSHIP_STATUS_LABELS: Record<MembershipStatus, string> = {
+  [MEMBERSHIP_STATUS.PENDING_APPROVAL]: "Pending Approval",
+  [MEMBERSHIP_STATUS.APPROVED]: "Approved",
+  [MEMBERSHIP_STATUS.REJECTED]: "Rejected",
+};
+
+export function getMembershipStatusLabel(
+  status: string | null | undefined,
+): string {
+  if (!status) return "Unknown";
+  return (
+    MEMBERSHIP_STATUS_LABELS[status as MembershipStatus] ?? status
+  );
+}

--- a/joca-app/src/lib/membership-plans.ts
+++ b/joca-app/src/lib/membership-plans.ts
@@ -1,0 +1,31 @@
+export const MEMBERSHIP_PLANS = [
+  { id: "senior-membership", label: "Senior Membership" },
+  { id: "general-membership", label: "General Membership" },
+  { id: "family-membership", label: "Family Membership" },
+  {
+    id: "student-associate-membership",
+    label: "Student / Associate Membership",
+  },
+] as const;
+
+export type MembershipPlanId = (typeof MEMBERSHIP_PLANS)[number]["id"];
+
+export const MEMBERSHIP_PLAN_IDS = MEMBERSHIP_PLANS.map((p) => p.id);
+
+export const MEMBERSHIP_STATUS = {
+  PENDING_APPROVAL: "pending_approval",
+  APPROVED: "approved",
+  REJECTED: "rejected",
+} as const;
+
+export type MembershipStatus =
+  (typeof MEMBERSHIP_STATUS)[keyof typeof MEMBERSHIP_STATUS];
+
+export function isMembershipPlanId(value: string): value is MembershipPlanId {
+  return (MEMBERSHIP_PLAN_IDS as readonly string[]).includes(value);
+}
+
+export function getPlanLabel(planId: string | null | undefined): string {
+  if (!planId) return "Unknown plan";
+  return MEMBERSHIP_PLANS.find((p) => p.id === planId)?.label ?? planId;
+}

--- a/joca-app/src/lib/resend.ts
+++ b/joca-app/src/lib/resend.ts
@@ -1,0 +1,14 @@
+import { Resend } from "resend";
+
+const isDev = process.env.NODE_ENV === "development";
+
+const resendApiKey = process.env.RESEND_API_KEY;
+if (!isDev && !resendApiKey) {
+  throw new Error("RESEND_API_KEY environment variable is not set.");
+}
+
+/** Null in development when Resend isn't configured; production always has a client. */
+export const resend = resendApiKey ? new Resend(resendApiKey) : null;
+
+/** Temporary until JOCA domain is verified in Resend. */
+export const EMAIL_FROM = "onboarding@resend.dev";


### PR DESCRIPTION
## Summary
- Gate new memberships on staff approval: after email verification, notify `JOCA_APPROVALS_EMAIL`, then staff approve/reject via a signed link that emails a Stripe Checkout URL.
- Pending members can use Account/Sign Out; Elections stays visible but payment-gated; Manage membership appears only after an active subscription.
- Approval UI polish: shadcn Select, human-readable status labels, and one-shot approve/reject.

## Test plan
- [ ] Sign up with a suggested plan → verify (or skip) → land on `/pending`; JOCA notification / approve URL available
- [ ] Approve with plan override → member gets Checkout link → pay with test card → Elections + Manage membership unlock
- [ ] Reject once → form locks; second approve/reject is blocked server-side
- [ ] Unapproved `/payment` redirects to `/pending`
- [ ] Logged-in unpaid user sees Elections in header but gated elections page
- [ ] `stripe listen` + test keys for local webhook activation
